### PR TITLE
treehouses rename input check (fixes #315)

### DIFF
--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,13 +2,15 @@
 
 function rename () {
 
+space="$2" 
+
   if
     [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
     [[ ${1: -1} == "-" ]] || #checks end for "-"
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ] || #Checks if variable is empty
-    [ -e "$2" ];
+    [ ! -z "$space" ];
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -22,9 +22,9 @@ function rename () {
     echo "Unsuccessful: Make sure to remove special characters."
   else
     CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
-    echo "$1" > /etc/hostname
+    echo "$#" > /etc/hostname
     sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\\t$1/g" /etc/hosts
-    hostname "$1"
+    hostname "$#"
     echo "Success: the hostname has been modified"
   fi
 }

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -8,7 +8,7 @@ function rename () {
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ] || #Checks if variable is empty
-    [[ -z "$2" ]];
+    [[ ! -z "$2" ]];
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,9 +2,9 @@
 
 function rename () { 
 
-  if [ -n "$1"]; then
+  if [ -n "$1" ]; then
      space="$2"
-     if [ -n "space"]; then
+     if [ -n "space" ]; then
      echo "Unsuccessful: Make sure to remove space."
      fi
   fi

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -20,9 +20,9 @@ function rename () {
   then
     echo "Unsuccessful: Make sure to remove special characters."
   else
-    CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
-    echo "$1" > /etc/hostname
-    sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\\t$1/g" /etc/hosts
+   # CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
+    #echo "$1" > /etc/hostname
+    #sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\\t$1/g" /etc/hosts
    # hostname "$1"
     echo "Success: the hostname has been modified"
   fi

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -4,7 +4,7 @@ function rename () {
 
   if [ -n "$1" ]; then
      space="$2"
-     if [ -n "space" ]; then
+     if [ -n "$space" ]; then
      echo "Unsuccessful: Make sure to remove space."
      fi
   fi

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,14 +2,14 @@
 
 function rename () { 
 
-  if [ -n "$1" ]; then
-     option=$2
-     echo " $option "
-  fi
+  #if [ -n "$1" ]; then
+  #   option=$2
+  #   echo " $option "
+  #fi
   
-  if [[ "$#" -ne 1 ]]; then
-    echo "Illegal number of parameters"
-  fi
+  #if [[ "$#" -ne 1 ]]; then
+  #  echo "Illegal number of parameters"
+  #fi
 
   if
     [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
@@ -19,6 +19,8 @@ function rename () {
     [ -z "$1" ]; #Checks if variable is empty
   then
     echo "Unsuccessful: Make sure to remove special characters."
+    echo "$1"
+    printf "$1"
   else
     CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
     echo "$1" > /etc/hostname

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-function rename () {
-
-space="$2" 
+function rename () { 
 
   if
     [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
@@ -10,7 +8,7 @@ space="$2"
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ] || #Checks if variable is empty
-    [[ -z "$space" ]];
+    [[ -z "$2" ]];
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,7 +2,7 @@
 
 function rename () { 
 
-  if [ ARG_MAX > 1 ]; then
+  if [ ARG_MAX > 2 ]; then
      echo "Unsuccessful: Make sure to remove space."
   fi
 

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,9 +2,8 @@
 
 function rename () {
   if
-    [ "$(expr "$1" : ".*[!@#\$%^\&*()_+].*")" -gt 0 ] || #checks for special characters
-    echo "$1" | grep -E '[ "]' >/dev/null || #Checks for spaces
-    [[ ${#1} -gt "64" ]]|| #Checks for length greater than 64
+    ! [[ "$1" =~ ^[[:alnum:]]*$ ]] || #checks for special characters and spaces
+    [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ]; #Checks if variable is empty
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -5,7 +5,7 @@ function rename () {
   #if [[ $# -gt "2" ]]; then
    #  echo "Unsuccessful: Make sure to remove space."
    getconf ARG_MAX
-     echo " $@ "
+     echo " $N "
   #fi
 
   if

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,7 +2,7 @@
 
 function rename () { 
 
-  if [ ARG_MAX > 3 ]; then
+  if [ $# > 1 ]; then
      echo "Unsuccessful: Make sure to remove space."
   fi
 

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,7 +2,7 @@
 
 function rename () { 
 
-  if [ ARG_MAX > 1]; then
+  if [ ARG_MAX > 1 ]; then
      echo "Unsuccessful: Make sure to remove space."
      fi
   fi

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -7,7 +7,7 @@ function rename () {
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ]; #Checks if variable is empty
-    [ z "$2" ]; #Checks for another variable technicaly = space in our case 
+    [ -s "$2" ]; #Checks for another variable technicaly = space in our case 
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -10,7 +10,7 @@ space="$2"
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ] || #Checks if variable is empty
-    [ "$space" != " " ];
+    [ ! -z "$space" ];
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -10,7 +10,7 @@ space="$2"
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ] || #Checks if variable is empty
-    [ ! -z "$space" ];
+    [ "$space" != " " ];
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -7,6 +7,10 @@ function rename () {
    getconf ARG_MAX
      echo " $N "
   #fi
+  
+  if [ "$#" -ne 1 ]; then
+    echo "Illegal number of parameters"
+  fi
 
   if
     [[ ${1:0:1} == "-" ]] || #checks beginning for "-"

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,9 +2,7 @@
 
 function rename () { 
 
-  if [ -n "$1" ]; then
-     space="$2"
-     if [ ! -z "$space" ]; then
+  if [ ARG_MAX > 1]; then
      echo "Unsuccessful: Make sure to remove space."
      fi
   fi

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,7 +2,9 @@
 
 function rename () {
   if
-    ! [[ "$1" =~ ^[[:alnum:]]*$ ]] || #checks for special characters and spaces
+    [[ ${1:01} == "-" ]] || #checks beginning for "-"
+    [[ ${1: -1} == "-" ]] || #checks end for "-"
+    ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ]; #Checks if variable is empty
   then

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -8,7 +8,7 @@ function rename () {
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ] || #Checks if variable is empty
-    [ "$1" = [[:blank:]] ];
+    [[ "$1" = [[:blank:]] ]];
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -7,6 +7,7 @@ function rename () {
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ]; #Checks if variable is empty
+    [ z "$2" ]; #Checks for another variable technicaly = space in our case 
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -4,7 +4,7 @@ function rename () {
 
   if [ -n "$1" ]; then
      space="$2"
-     if [ -n "$space" ]; then
+     if [[ -z "$space" ]]; then
      echo "Unsuccessful: Make sure to remove space."
      fi
   fi

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -8,7 +8,7 @@ function rename () {
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ] || #Checks if variable is empty
-    [ "$2" = " "];
+    ! [ -z "$2" ];
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,7 +2,7 @@
 
 function rename () { 
 
-  if [ $# > 1 ]; then
+  if [ $# -gt 1 ]; then
      echo "Unsuccessful: Make sure to remove space."
   fi
 

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,7 +2,7 @@
 
 function rename () { 
 
-  if [ "$#" -gt 1 ]; then
+  if [[ $# -gt "1" ]]; then
      echo "Unsuccessful: Make sure to remove space."
   fi
 

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,9 +2,10 @@
 
 function rename () { 
 
-  if [[ $# -gt "2" ]]; then
-     echo "Unsuccessful: Make sure to remove space."
-  fi
+  #if [[ $# -gt "2" ]]; then
+   #  echo "Unsuccessful: Make sure to remove space."
+     echo " $# "
+  #fi
 
   if
     [[ ${1:0:1} == "-" ]] || #checks beginning for "-"

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -4,8 +4,7 @@ function rename () {
 
   #if [[ $# -gt "2" ]]; then
    #  echo "Unsuccessful: Make sure to remove space."
-   getconf ARG_MAX
-     echo " $N "
+     echo " $# "
   #fi
   
   if [[ "$#" -ne 1 ]]; then
@@ -24,7 +23,7 @@ function rename () {
     CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
     echo "$1" > /etc/hostname
     sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\\t$1/g" /etc/hosts
-    hostname "$1"
+   # hostname "$1"
     echo "Success: the hostname has been modified"
   fi
 }

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -11,21 +11,21 @@ function rename () {
     echo "Illegal number of parameters"
   fi
 
-  if
+#  if
    # [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
    # [[ ${1: -1} == "-" ]] || #checks end for "-"
    # ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
    # [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
    # [ -z "$1" ]; #Checks if variable is empty
-  then
+#  then
     echo "Unsuccessful: Make sure to remove special characters."
-  else
+#  else
    # CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
     #echo "$1" > /etc/hostname
     #sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\\t$1/g" /etc/hosts
    # hostname "$1"
     echo "Success: the hostname has been modified"
-  fi
+#  fi
 }
 
 function rename_help () {

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -8,7 +8,7 @@ function rename () {
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ] || #Checks if variable is empty
-    ! [ -z "$2" ];
+    [ "$1" = [[:blank:]] ];
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -7,7 +7,7 @@ function rename () {
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ]; #Checks if variable is empty
-    [ -s "$2" ]; #Checks for another variable technicaly = space in our case 
+    [ ! -z "$2" ]; #Checks for another variable technicaly = space in our case 
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,7 +2,7 @@
 
 function rename () {
   if
-    [[ ${1:01} == "-" ]] || #checks beginning for "-"
+    [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
     [[ ${1: -1} == "-" ]] || #checks end for "-"
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -4,7 +4,7 @@ function rename () {
 
   if [ -n "$1" ]; then
      space="$2"
-     if [[ -z "$space" ]]; then
+     if [ ! -z "$space" ]; then
      echo "Unsuccessful: Make sure to remove space."
      fi
   fi

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,19 +2,9 @@
 
 function rename () { 
 
-  if [ -n "$1" ]; then
-     echo "Positional Parameters"
-echo '$0 = ' $0
-echo '$1 = ' $1
-echo '$2 = ' $2
-echo '$3 = ' $3
-  fi
-  
   #if [[ "$#" -ne 1 ]]; then
   #  echo "Illegal number of parameters"
   #fi
-  
-  echo "$1 $2 $3"
 
   if
     [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
@@ -29,7 +19,7 @@ echo '$3 = ' $3
     echo "$1" > /etc/hostname
     sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\\t$1/g" /etc/hosts
     hostname "$1"
-    echo "Success: the hostname has been modified"
+    echo "Success: the hostname has been modified to $1"
   fi
 }
 

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,8 +2,9 @@
 
 function rename () { 
 
-  if [ -n "$2"]; then
-     echo " $2 "
+  if [ -n "$1"]; then
+     option=$2
+     echo " $option "
   fi
   
   if [[ "$#" -ne 1 ]]; then

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -4,7 +4,7 @@ function rename () {
 
   #if [[ $# -gt "2" ]]; then
    #  echo "Unsuccessful: Make sure to remove space."
-     echo " $# "
+     echo " $@ "
   #fi
 
   if

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -4,6 +4,7 @@ function rename () {
 
   #if [[ $# -gt "2" ]]; then
    #  echo "Unsuccessful: Make sure to remove space."
+   getconf ARG_MAX
      echo " $@ "
   #fi
 

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -5,7 +5,7 @@ function rename () {
     [ "$(expr "$1" : ".*[!@#\$%^\&*()_+].*")" -gt 0 ] || #checks for special characters
     echo "$1" | grep -E '[ "]' >/dev/null || #Checks for spaces
     [[ ${#1} -gt "64" ]]|| #Checks for length greater than 64
-    [ -z "$var" ]; #Checks if variable is empty
+    [ -z "$1" ]; #Checks if variable is empty
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,15 +2,21 @@
 
 function rename () { 
 
+  if [ -n "$1"]; then
+     space="$2"
+     if [ -n "space"]; then
+     echo "Unsuccessful: Make sure to remove space."
+     fi
+  fi
+
   if
     [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
     [[ ${1: -1} == "-" ]] || #checks end for "-"
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
-    [ -z "$1" ] || #Checks if variable is empty
-    [ -n "$2" ];
+    [ -z "$1" ]; #Checks if variable is empty
   then
-    echo "Unsuccessful: Make sure to remove special characters and spaces."
+    echo "Unsuccessful: Make sure to remove special characters."
   else
     CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
     echo "$1" > /etc/hostname

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,7 +2,7 @@
 
 function rename () { 
 
-  if [[ $# -gt "1" ]]; then
+  if [[ $# -gt "2" ]]; then
      echo "Unsuccessful: Make sure to remove space."
   fi
 

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -8,7 +8,7 @@ function rename () {
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ] || #Checks if variable is empty
-    [ ! -z "$2" ];
+    [ -e "$2" ];
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -10,7 +10,7 @@ space="$2"
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ] || #Checks if variable is empty
-    [ ! -z "$space" ];
+    [[ -z "$space" ]];
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -19,8 +19,8 @@ function rename () {
     [ -z "$1" ]; #Checks if variable is empty
   then
     echo "Unsuccessful: Make sure to remove special characters."
-    echo "$1"
     printf "$1"
+    echo "$1"    
   else
     CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
     echo "$1" > /etc/hostname

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,7 +2,7 @@
 
 function rename () { 
 
-  if [ -n "$1"]; then
+  if [ -n "$1" ]; then
      option=$2
      echo " $option "
   fi

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -8,7 +8,7 @@ function rename () {
      echo " $N "
   #fi
   
-  if [ "$#" -ne 1 ]; then
+  if [[ "$#" -ne 1 ]]; then
     echo "Illegal number of parameters"
   fi
 
@@ -22,9 +22,9 @@ function rename () {
     echo "Unsuccessful: Make sure to remove special characters."
   else
     CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
-    echo "$#" > /etc/hostname
+    echo "$1" > /etc/hostname
     sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\\t$1/g" /etc/hosts
-    hostname "$#"
+    hostname "$1"
     echo "Success: the hostname has been modified"
   fi
 }

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -10,6 +10,8 @@ function rename () {
   #if [[ "$#" -ne 1 ]]; then
   #  echo "Illegal number of parameters"
   #fi
+  
+  echo "$1 $2 $3"
 
   if
     [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
@@ -18,9 +20,7 @@ function rename () {
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ]; #Checks if variable is empty
   then
-    echo "Unsuccessful: Make sure to remove special characters."
-    printf "$1"
-    echo "$1"    
+    echo "Unsuccessful: Make sure to remove special characters."  
   else
     CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
     echo "$1" > /etc/hostname

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -4,7 +4,6 @@ function rename () {
 
   if [ ARG_MAX > 1 ]; then
      echo "Unsuccessful: Make sure to remove space."
-     fi
   fi
 
   if

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,10 +2,10 @@
 
 function rename () { 
 
-  #if [ -n "$1" ]; then
-  #   option=$2
-  #   echo " $option "
-  #fi
+  if [ -n "$1" ]; then
+     shift
+     echo " $1 "
+  fi
   
   #if [[ "$#" -ne 1 ]]; then
   #  echo "Illegal number of parameters"

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -8,7 +8,7 @@ function rename () {
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ] || #Checks if variable is empty
-    [[ "$1" = [[:blank:]] ]];
+    [ -n "$2" ];
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -3,8 +3,11 @@
 function rename () { 
 
   if [ -n "$1" ]; then
-     shift
-     echo " $1 "
+     echo "Positional Parameters"
+echo '$0 = ' $0
+echo '$1 = ' $1
+echo '$2 = ' $2
+echo '$3 = ' $3
   fi
   
   #if [[ "$#" -ne 1 ]]; then

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,30 +2,29 @@
 
 function rename () { 
 
-  #if [[ $# -gt "2" ]]; then
-   #  echo "Unsuccessful: Make sure to remove space."
-     echo " $# "
-  #fi
+  if [ -n "$2"]; then
+     echo " $2 "
+  fi
   
   if [[ "$#" -ne 1 ]]; then
     echo "Illegal number of parameters"
   fi
 
-#  if
-   # [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
-   # [[ ${1: -1} == "-" ]] || #checks end for "-"
-   # ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
-   # [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
-   # [ -z "$1" ]; #Checks if variable is empty
-#  then
+  if
+    [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
+    [[ ${1: -1} == "-" ]] || #checks end for "-"
+    ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
+    [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
+    [ -z "$1" ]; #Checks if variable is empty
+  then
     echo "Unsuccessful: Make sure to remove special characters."
-#  else
-   # CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
-    #echo "$1" > /etc/hostname
-    #sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\\t$1/g" /etc/hosts
-   # hostname "$1"
+  else
+    CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
+    echo "$1" > /etc/hostname
+    sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\\t$1/g" /etc/hosts
+    hostname "$1"
     echo "Success: the hostname has been modified"
-#  fi
+  fi
 }
 
 function rename_help () {

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 
 function rename () {
-  CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
-  echo "$1" > /etc/hostname
-  sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\\t$1/g" /etc/hosts
-  hostname "$1"
-  echo "Success: the hostname has been modified"
+  if
+    [ "$(expr "$1" : ".*[!@#\$%^\&*()_+].*")" -gt 0 ] || #checks for special characters
+    echo "$1" | grep -E '[ "]' >/dev/null || #Checks for spaces
+    [[ ${#1} -gt "64" ]]|| #Checks for length greater than 64
+    [ -z "$var" ]; #Checks if variable is empty
+  then
+    echo "Unsuccessful: Make sure to remove special characters and spaces."
+  else
+    CURRENT_HOSTNAME=$(< /etc/hostname tr -d " \\t\\n\\r")
+    echo "$1" > /etc/hostname
+    sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\\t$1/g" /etc/hosts
+    hostname "$1"
+    echo "Success: the hostname has been modified"
+  fi
 }
 
 function rename_help () {

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,10 +2,6 @@
 
 function rename () { 
 
-  #if [[ "$#" -ne 1 ]]; then
-  #  echo "Illegal number of parameters"
-  #fi
-
   if
     [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
     [[ ${1: -1} == "-" ]] || #checks end for "-"

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 function rename () {
+
   if
     [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
     [[ ${1: -1} == "-" ]] || #checks end for "-"
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
-    [ -z "$1" ]; #Checks if variable is empty
-    [ ! -z "$2" ]; #Checks for another variable technicaly = space in our case 
+    [ -z "$1" ] || #Checks if variable is empty
+    [ ! -z "$2" ];
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,7 +2,7 @@
 
 function rename () { 
 
-  if [ $# -gt 1 ]; then
+  if [ "$#" -gt 1 ]; then
      echo "Unsuccessful: Make sure to remove space."
   fi
 

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -2,7 +2,7 @@
 
 function rename () { 
 
-  if [ ARG_MAX > 2 ]; then
+  if [ ARG_MAX > 3 ]; then
      echo "Unsuccessful: Make sure to remove space."
   fi
 

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -8,7 +8,7 @@ function rename () {
     ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
     [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
     [ -z "$1" ] || #Checks if variable is empty
-    [[ ! -z "$2" ]];
+    [ "$2" = " "];
   then
     echo "Unsuccessful: Make sure to remove special characters and spaces."
   else

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -12,11 +12,11 @@ function rename () {
   fi
 
   if
-    [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
-    [[ ${1: -1} == "-" ]] || #checks end for "-"
-    ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
-    [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
-    [ -z "$1" ]; #Checks if variable is empty
+   # [[ ${1:0:1} == "-" ]] || #checks beginning for "-"
+   # [[ ${1: -1} == "-" ]] || #checks end for "-"
+   # ! [[ "$1" =~ ^[[:alnum:]"-"]*$ ]] || #checks for special characters and spaces excluding "-"
+   # [[ ${#1} -gt "64" ]] || #Checks for length greater than 64
+   # [ -z "$1" ]; #Checks if variable is empty
   then
     echo "Unsuccessful: Make sure to remove special characters."
   else

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.7.0",
+  "version": "1.7.8",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
## Description
Fixes error with inputting underscore/special characters when changing hostname

checks for
-special characters
-spaces
-length greater than 64
-no input

So that it conforms closely to debian hostname perferences shown below

## Screenshot
![Screen Shot 2019-08-18 at 4 08 12 PM](https://user-images.githubusercontent.com/16839815/63225640-6bf4a980-c1d2-11e9-95ac-a4bfc63da8d9.png)
