### PR TITLE
add space after postuninstall (fix #425)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "postinstall": "if [ $(id -u) = 0 ]; then ln -sr _treehouses /etc/bash_completion.d/_treehouses; fi && exit 0",
-    "postuninstall":"if [ $(id -u) = 0 ]; then rm /etc/bash_completion.d/_treehouses; fi && exit 0",
+    "postuninstall": "if [ $(id -u) = 0 ]; then rm /etc/bash_completion.d/_treehouses; fi && exit 0",
     "test": "echo \"Error: no test specified\" && exit 0"
   },
   "keywords": [


### PR DESCRIPTION
I think that I omitted space after "postuninstall":
I think that it might cause the postinstall script not work.