### PR TITLE
treehouses discover (fixes #448)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ image                                     returns version of the system image in
 detectrpi                                 detects the hardware version of a raspberry pi
 detect                                    detects the hardware version of any device
 ethernet <ip> <mask> <gateway> <dns>      configures rpi network interface to a static ip address
+echo "   discover <rpi|ip|hostif|ping>    performs network scan and discovers all raspberry pis on the network"
+echo "            [ipaddress|url]
 wifi <ESSID> [password]                   connects to a wifi network
 staticwifi <ip> <mask> <gateway> <dns>    configures rpi wifi interface to a static ip address
            <ESSID> [password]

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ image                                     returns version of the system image in
 detectrpi                                 detects the hardware version of a raspberry pi
 detect                                    detects the hardware version of any device
 ethernet <ip> <mask> <gateway> <dns>      configures rpi network interface to a static ip address
-echo "   discover <rpi|ip|hostif|ping>    performs network scan and discovers all raspberry pis on the network"
-echo "            [ipaddress|url]
+discover <rpi|scan|interface|ping|ports>  performs network scan and discovers all raspberry pis on the network
+         [ipaddress|url]
 wifi <ESSID> [password]                   connects to a wifi network
 staticwifi <ip> <mask> <gateway> <dns>    configures rpi wifi interface to a static ip address
            <ESSID> [password]

--- a/README.md
+++ b/README.md
@@ -63,4 +63,5 @@ coralenv [install|demo-on|demo-off]       plays with the coral environmental boa
          [demo-always-on]
 memory [total|used|free]                  displays the total memory of the device, the memory used as well as the available free memory 
 temperature [celsius]                     displays raspberry pi's CPU temperature
+speedtest                                 tests internet download and upload speed
 ```

--- a/cli.sh
+++ b/cli.sh
@@ -48,6 +48,7 @@ source "$SCRIPTFOLDER/modules/wifi.sh"
 source "$SCRIPTFOLDER/modules/wificountry.sh"
 source "$SCRIPTFOLDER/modules/clone.sh"
 source "$SCRIPTFOLDER/modules/coralenv.sh"
+source "$SCRIPTFOLDER/modules/speedtest.sh"
 
 
 
@@ -245,6 +246,10 @@ case $1 in
   temperature)
     checkrpi
     temperature "$2"
+    ;;
+  speedtest)
+    shift
+    speedtest "$@"
     ;;
   help)
     help "$2"

--- a/cli.sh
+++ b/cli.sh
@@ -49,7 +49,7 @@ source "$SCRIPTFOLDER/modules/wificountry.sh"
 source "$SCRIPTFOLDER/modules/clone.sh"
 source "$SCRIPTFOLDER/modules/coralenv.sh"
 source "$SCRIPTFOLDER/modules/speedtest.sh"
-
+source "$SCRIPTFOLDER/modules/discover.sh"
 
 
 case $1 in
@@ -112,6 +112,10 @@ case $1 in
     checkrpi
     checkroot
     ethernet "$2" "$3" "$4" "$5"
+    ;;
+  discover)
+    checkrpi
+    discover "$2" "$3"
     ;;
   ap)
     checkrpi

--- a/cli.sh
+++ b/cli.sh
@@ -113,16 +113,15 @@ case $1 in
     checkroot
     ethernet "$2" "$3" "$4" "$5"
     ;;
-  discover)
-    checkrpi
-    shift
-    discover "$@"
-    ;;
   ap)
     checkrpi
     checkroot
     shift
     ap "$@"
+    ;;
+  discover)
+    shift
+    discover "$@"
     ;;
   timezone)
     checkroot

--- a/modules/discover.sh
+++ b/modules/discover.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 function discover {
+  check_missing_packages "nmap"
+  /usr/bin/nmap "$@"
+
   option=$1
   if [ $option = "ip" ] || [ $option = "ping" ]
   then
@@ -12,15 +15,17 @@ function discover {
       nmap --iflist | grep DC:A6:32
       nmap --iflist | grep B8:27:EB
       ;;
-    ip)
+    scan)
       nmap -v -A -T4  $ip
       ;;
-    hostif)
+    interface)
       nmap --iflist
       ;; 
     ping)
       nmap -sP $ip
       ;;
+    ports)
+      nmap --open $ip
     *)
       echo "Unknown operation provided." 1>&2
       discover_help
@@ -31,7 +36,7 @@ function discover {
 
 function discover_help {
   echo ""
-  echo "Usage: $(basename "$0") discover <rpi|ip|hostif|ping ip|[ipaddress|url]>"
+  echo "Usage: $(basename "$0") discover <rpi|scan|hostinterface|ping|ports ip|ping|ports[ipaddress|url]>"
   echo ""
   echo "Scans the network provdied and shows the open ports. Can scan for all raspberry pis on the network as well."
   echo ""
@@ -40,10 +45,13 @@ function discover_help {
   echo "    Detects raspberry pis on the network."
   echo " $(basename "$0") discover ip 192.168.7.149"
   echo "    Performs a network scan of the provided ip address."
-  echo " $(basename "$0") discover ip scanme.nmap.org"
+  echo " $(basename "$0") discover scan scanme.nmap.org"
   echo "    Performs a network scan of the provided url."
-  echo " $(basename "$0") discover hostif"
+  echo " $(basename "$0") discover interface"
   echo "    Displays the host interfaces and routes on the network."
   echo " $(basename "$0") discover ping 192.168.7.149"
   echo "    Displays servers and devices running on network provided."
+  echo " $(basename "$0") discover ports 192.168.7.149"
+  echo "    Displays open ports."
+  echo ""
 }

--- a/modules/discover.sh
+++ b/modules/discover.sh
@@ -2,22 +2,25 @@
 
 function discover {
   check_missing_packages "nmap"
-  #/usr/bin/nmap "$@"
+
+  option=$1
   
-  if [ "$#" -gt 2 ]
-  then 
+  if [ "$#" -gt 2 ]; then 
     echo "Too many arguments."
     discover_help
     exit 1
   fi 
 
-  option=$1
+  if [ $option = "rpi" ] || [ $option = "interface" ]; then
+    if [ $# -gt 1 ]; then
+      echo "Too many arguments."
+      discover_help
+      exit 1
+    fi
+  fi
 
-  if [ $option = "scan" ] || [ $option = "ping" ] || [ $option = "ports" ]
-
-  then
-    if [ -z $2 ]
-    then 
+  if [ $option = "scan" ] || [ $option = "ping" ] || [ $option = "ports" ]; then
+    if [ -z $2 ]; then 
       echo "You need to provide an IP address or URL for this command".
       exit 1
     fi
@@ -26,12 +29,6 @@ function discover {
   
   case $option in
     rpi)
-      if [ $# -gt 1 ]
-      then
-        echo "Too many arguments."
-        discover_help
-        exit 1
-      fi
       nmap --iflist | grep DC:A6:32
       nmap --iflist | grep B8:27:EB
       ;;
@@ -39,12 +36,6 @@ function discover {
       nmap -v -A -T4  $ip
       ;;
     interface)
-      if [ $# -gt 1 ]
-      then
-        echo "Too many arguments."
-        discover_help
-        exit 1
-      fi 
       nmap --iflist
       ;; 
     ping)
@@ -59,7 +50,6 @@ function discover {
       exit 1
       ;;
   esac
-
 }
 
 

--- a/modules/discover.sh
+++ b/modules/discover.sh
@@ -56,11 +56,8 @@ function discover {
     *)
       echo "Unknown operation provided." 1>&2
       discover_help
-<<<<<<< HEAD
       exit 1
-=======
       ;;
->>>>>>> 9581309d6c9f3f58586900ddf2f535b9fcaf52ee
   esac
 
 }

--- a/modules/discover.sh
+++ b/modules/discover.sh
@@ -12,12 +12,9 @@ function discover {
   fi 
 
   option=$1
-<<<<<<< HEAD
 
   if [ $option = "scan" ] || [ $option = "ping" ] || [ $option = "ports" ]
-=======
-  if [ $option = "ip" ] || [ $option = "ping" ] || [ $option = "ports" ]
->>>>>>> 9581309d6c9f3f58586900ddf2f535b9fcaf52ee
+
   then
     if [ -z $2 ]
     then 

--- a/modules/discover.sh
+++ b/modules/discover.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+function discover {
+  option=$1
+  if [ $option = "ip" ] || [ $option = "ping" ]
+  then
+    ip=$2
+  fi
+
+  case $option in
+    rpi)
+      nmap --iflist | grep DC:A6:32
+      nmap --iflist | grep B8:27:EB
+      ;;
+    ip)
+      nmap -v -A -T4  $ip
+      ;;
+    hostif)
+      nmap --iflist
+      ;; 
+    ping)
+      nmap -sP $ip
+      ;;
+    *)
+      echo "Unknown operation provided." 1>&2
+      discover_help
+  esac
+
+}
+
+
+function discover_help {
+  echo ""
+  echo "Usage: $(basename "$0") discover <rpi|ip|hostif|ping ip|[ipaddress|url]>"
+  echo ""
+  echo "Scans the network provdied and shows the open ports. Can scan for all raspberry pis on the network as well."
+  echo ""
+  echo "Example:"
+  echo " $(basename "$0") discover rpi"
+  echo "    Detects raspberry pis on the network."
+  echo " $(basename "$0") discover ip 192.168.7.149"
+  echo "    Performs a network scan of the provided ip address."
+  echo " $(basename "$0") discover ip scanme.nmap.org"
+  echo "    Performs a network scan of the provided url."
+  echo " $(basename "$0") discover hostif"
+  echo "    Displays the host interfaces and routes on the network."
+  echo " $(basename "$0") discover ping 192.168.7.149"
+  echo "    Displays servers and devices running on network provided."
+}

--- a/modules/discover.sh
+++ b/modules/discover.sh
@@ -2,16 +2,35 @@
 
 function discover {
   check_missing_packages "nmap"
-  /usr/bin/nmap "$@"
+  #/usr/bin/nmap "$@"
+  
+  if [ "$#" -gt 2 ]
+  then 
+    echo "Too many arguments."
+    discover_help
+    exit 1
+  fi 
 
   option=$1
-  if [ $option = "ip" ] || [ $option = "ping" ]
+
+  if [ $option = "scan" ] || [ $option = "ping" ] || [ $option = "ports" ]
   then
+    if [ -z $2 ]
+    then 
+      echo "You need to provide an IP address or URL for this command".
+      exit 1
+    fi
     ip=$2
   fi
-
+  
   case $option in
     rpi)
+      if [ $# -gt 1 ]
+      then
+        echo "Too many arguments."
+        discover_help
+        exit 1
+      fi
       nmap --iflist | grep DC:A6:32
       nmap --iflist | grep B8:27:EB
       ;;
@@ -19,6 +38,12 @@ function discover {
       nmap -v -A -T4  $ip
       ;;
     interface)
+      if [ $# -gt 1 ]
+      then
+        echo "Too many arguments."
+        discover_help
+        exit 1
+      fi 
       nmap --iflist
       ;; 
     ping)
@@ -26,9 +51,11 @@ function discover {
       ;;
     ports)
       nmap --open $ip
+      ;;
     *)
       echo "Unknown operation provided." 1>&2
       discover_help
+      exit 1
   esac
 
 }
@@ -43,7 +70,7 @@ function discover_help {
   echo "Example:"
   echo " $(basename "$0") discover rpi"
   echo "    Detects raspberry pis on the network."
-  echo " $(basename "$0") discover ip 192.168.7.149"
+  echo " $(basename "$0") discover scan 192.168.7.149"
   echo "    Performs a network scan of the provided ip address."
   echo " $(basename "$0") discover scan scanme.nmap.org"
   echo "    Performs a network scan of the provided url."

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -56,6 +56,7 @@ function help_default {
   echo "            [demo-always-on]"
   echo "   memory [total|used|free]                  displays the total memory of the device, the memory used as well as the available free memory"
   echo "   temperature [celsius]                     displays raspberry pi's CPU temperature"
+  echo "   speedtest                                 tests internet download and upload speed"
   echo
 }
 

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -15,6 +15,7 @@ function help_default {
   echo "   detectrpi                                 detects the hardware version of a raspberry pi"
   echo "   detect                                    detects the hardware version of any device"
   echo "   ethernet <ip> <mask> <gateway> <dns>      configures rpi network interface to a static ip address"
+  echo "   discover <rpi|ip|hostif|ping> [ipaddress|url]  performs network scan and discovers all raspberry pis on the network"
   echo "   wifi <ESSID> [password]                   connects to a wifi network"
   echo "   staticwifi <ip> <mask> <gateway> <dns>    configures rpi wifi interface to a static ip address"
   echo "              <ESSID> [password]"

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -15,7 +15,7 @@ function help_default {
   echo "   detectrpi                                 detects the hardware version of a raspberry pi"
   echo "   detect                                    detects the hardware version of any device"
   echo "   ethernet <ip> <mask> <gateway> <dns>      configures rpi network interface to a static ip address"
-  echo "   discover <rpi|ip|hostif|ping>             performs network scan and discovers all raspberry pis on the network"
+  echo "   discover <rpi|scan|interface|ping|ports>  performs network scan and discovers all raspberry pis on the network"
   echo "            [ipaddress|url]"
   echo "   wifi <ESSID> [password]                   connects to a wifi network"
   echo "   staticwifi <ip> <mask> <gateway> <dns>    configures rpi wifi interface to a static ip address"

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -15,7 +15,8 @@ function help_default {
   echo "   detectrpi                                 detects the hardware version of a raspberry pi"
   echo "   detect                                    detects the hardware version of any device"
   echo "   ethernet <ip> <mask> <gateway> <dns>      configures rpi network interface to a static ip address"
-  echo "   discover <rpi|ip|hostif|ping> [ipaddress|url]  performs network scan and discovers all raspberry pis on the network"
+  echo "   discover <rpi|ip|hostif|ping>             performs network scan and discovers all raspberry pis on the network"
+  echo "            [ipaddress|url]
   echo "   wifi <ESSID> [password]                   connects to a wifi network"
   echo "   staticwifi <ip> <mask> <gateway> <dns>    configures rpi wifi interface to a static ip address"
   echo "              <ESSID> [password]"

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -16,7 +16,7 @@ function help_default {
   echo "   detect                                    detects the hardware version of any device"
   echo "   ethernet <ip> <mask> <gateway> <dns>      configures rpi network interface to a static ip address"
   echo "   discover <rpi|ip|hostif|ping>             performs network scan and discovers all raspberry pis on the network"
-  echo "            [ipaddress|url]
+  echo "            [ipaddress|url]"
   echo "   wifi <ESSID> [password]                   connects to a wifi network"
   echo "   staticwifi <ip> <mask> <gateway> <dns>    configures rpi wifi interface to a static ip address"
   echo "              <ESSID> [password]"

--- a/modules/speedtest.sh
+++ b/modules/speedtest.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+function speedtest {
+  check_missing_packages "speedtest-cli"
+  /usr/bin/speedtest "$@"
+}
+function speedtest_help {
+
+  echo ""
+  echo "Usage: $(basename "$0") speedtest"
+  echo ""
+  echo "tests internet download and upload speed"
+  echo ""
+  echo "Examples:"
+  echo "  $(basename "$0") speedtest"
+  echo "      Outputs the speed of internet download and upload speed"
+  echo ""
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.8.6",
+  "version": "1.9.0",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
discover <rpi|ip|hostif|ping ip[ipaddress|url]
Usage: 
  * `./cli.sh discover rpi` displays raspberry pis on network
  * `./cli.sh discover ping 192.168.7.151` performs network scan of ip address
  * `./cli.sh discover interface` displays host interface
  * `./cli.sh discover scan 192.168.7.*` shows which devices are running
 * `./cli.sh discover ports 192.168.7.151` shows which ports are open
