### PR TITLE
fix install of bashcompletion _treehouses (fixes #453)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "url": "https://github.com/treehouses/cli.git"
   },
   "scripts": {
-    "postinstall": "if [ $(id -u) = 0 ]; then ln -sr _treehouses /etc/bash_completion.d/_treehouses; fi && exit 0",
-    "postuninstall": "if [ $(id -u) = 0 ]; then rm /etc/bash_completion.d/_treehouses; fi && exit 0",
     "test": "echo \"Error: no test specified\" && exit 0"
   },
   "keywords": [


### PR DESCRIPTION
delete wrong codes