### PR TITLE
refactor treehouses deletegithubusername (fixes #483)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
use grep to find the github user's key, then use sed to delete them.