### PR TITLE
treehouses camera <on|off>|[capture] (fixes #452)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,6 @@ coralenv [install|demo-on|demo-off]       plays with the coral environmental boa
 memory [total|used|free]                  displays the total memory of the device, the memory used as well as the available free memory 
 temperature [celsius]                     displays raspberry pi's CPU temperature
 speedtest                                 tests internet download and upload speed
+camera <on|off>                           enables or disables camera for [capture] use
+       [capture]                          captures and stores a picture from camera onto pi's Desktop
 ```

--- a/_treehouses
+++ b/_treehouses
@@ -5,7 +5,7 @@ _treehouses_complete()
   local cur prev
 
   # Valid top-level completions
-  commands="ap apchannel bluetooth bootoption bridge burn button clone container \
+  commands="ap apchannel bluetooth bootoption bridge burn button camera clone container \
               coralenv default detect detectrpi ethernet expandfs feedback help \
               image internet led locale memory networkmode ntp  openvpn password \
               rebootneeded rename restore rtc services speedtest ssh sshkey sshtunnel staticwifi \
@@ -19,7 +19,7 @@ _treehouses_complete()
   button_cmds="off bluetooth"
   container_cmds="none docker balena"
   coralenv_cmds="install demo-on demo-off demo-always-on"
-  help_cmds="ap apchannel bluetooth bootoption bridge burn button clone container \
+  help_cmds="ap apchannel bluetooth bootoption bridge burn button camera clone container \
               coralenv default detect detectrpi ethernet expandfs feedback help \
               image internet led locale memory networkmode ntp  openvpn password \
               rebootneeded rename restore rtc services speedtest ssh sshkey sshtunnel staticwifi \
@@ -70,6 +70,9 @@ vnc_cmds="on off info"
         ;;
       "button")
         COMPREPLY=( $(compgen -W "$button_cmds" -- $cur) )
+        ;;
+      "camera")
+        COMPREPLY=( $(compgen -W "$camera_cmds" -- $cur) )
         ;;
       "container")
         COMPREPLY=( $(compgen -W "$container_cmds" -- $cur) )

--- a/cli.sh
+++ b/cli.sh
@@ -3,7 +3,7 @@
 SCRIPTPATH=$(realpath "$0")
 SCRIPTFOLDER=$(dirname "$SCRIPTPATH")
 
-source "$SCRIPTFOLDER/modules/detectrpi.sh" 
+source "$SCRIPTFOLDER/modules/detectrpi.sh"
 source "$SCRIPTFOLDER/modules/globals.sh"
 source "$SCRIPTFOLDER/modules/ap.sh"
 source "$SCRIPTFOLDER/modules/apchannel.sh"
@@ -51,7 +51,7 @@ source "$SCRIPTFOLDER/modules/clone.sh"
 source "$SCRIPTFOLDER/modules/coralenv.sh"
 source "$SCRIPTFOLDER/modules/speedtest.sh"
 source "$SCRIPTFOLDER/modules/discover.sh"
-
+source "$SCRIPTFOLDER/modules/camera.sh"
 
 case $1 in
   expandfs)
@@ -258,6 +258,10 @@ case $1 in
   speedtest)
     shift
     speedtest "$@"
+    ;;
+  camera)
+    checkrpi
+    camera "$2" "$3"
     ;;
   help)
     help "$2"

--- a/modules/camera.sh
+++ b/modules/camera.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# potential improvements:
+#    treehouses camera saveat "directory"
+#    treehouses camera fliph
+#    treehouses camera flipv
+
+function camera {
+  directory="/home/pi/Pictures/"
+  case "$1" in
+    "on")
+      if grep "start_x=0" /boot/config.txt ; then
+        sed -i "s/start_x=0/start_x=1/g" /boot/config.txt
+        echo "Camera settings have been enabled. A reboot is needed in order to use the camera."
+      else
+        echo "Camera is already enabled. Use `$(basename "$0") camera capture` to take a photo."
+        echo "If you are having issues using the camera, try rebooting."
+      fi
+      ;;
+
+    "off")
+      if grep "start_x=1" /boot/config.txt ; then
+        sed -i "s/start_x=1/start_x=0/g" /boot/config.txt
+        echo "Camera has been disabled. Reboot needed for settings to take effect."
+      else
+        echo "Camera is already disabled. If camera is still enabled, try rebooting."
+      fi
+      ;;
+
+    "capture")
+      if grep "start_x=0" /boot/config.txt ; then
+        echo "You need to enable AND reboot first in order to take pictures."
+      else
+        echo "Camera is capturing and storying a time-stamped photo in ${directory}."
+        raspistill -n -o "${directory}$(basename "$0")_$(date +"%Y-%m-%d_%H:%M:%S").jpg"
+      fi
+      ;;
+
+    "")
+      camera_help
+      exit 0
+      ;;
+
+    "*")
+      camera_help
+      exit 0
+      ;;
+  esac
+}
+
+function camera_help {
+echo ""
+echo "  Usage: $(basename "$0") camera <on|off>        enables or disables camera for [capture] use"
+echo "         $(basename "$0") camera [capture]       captures and stores a picture from camera onto pi's Desktop"
+echo ""
+echo "  Example:"
+echo "    $(basename "$0") camera on"
+echo "      Camera settings have been enabled. A reboot is needed in order to use the camera"
+echo ""
+echo "    $(basename "$0") camera on"
+echo "      Camera is already enabled. Use `$(basename "$0") camera capture` to take a photo."
+echo ""
+echo "    $(basename "$0") camera capture"
+echo "      Camera is capturing and storying a time-stamped photo in /home/pi/Pictures."
+echo ""
+}

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -61,6 +61,8 @@ function help_default {
   echo "   memory [total|used|free]                  displays the total memory of the device, the memory used as well as the available free memory"
   echo "   temperature [celsius]                     displays raspberry pi's CPU temperature"
   echo "   speedtest                                 tests internet download and upload speed"
+  echo "   camera <on|off>                           enables or disables camera for [capture] use"
+  echo "          [capture]                          captures and stores a picture from camera onto pi's Desktop"
   echo
 }
 


### PR DESCRIPTION
```
Usage: 
    treehouses camera <on|off>        enables or disables camera for [capture] use
    treehouses camera [capture]       captures and stores a picture from camera onto pi's Desktop

Example:
    treehouses camera on
        Camera settings have been enabled. A reboot is needed in order to use the camera.

    treehouses camera on
        Camera is already enabled. Use `treehouses camera capture` to take a photo.

    treehouses camera capture
        Camera is capturing and storing a time-stamped photo in /home/pi/Pictures.
```