### PR TITLE
update sshkey help (fixes #497)

### DIFF
--- a/modules/sshkey.sh
+++ b/modules/sshkey.sh
@@ -178,7 +178,7 @@ function sshkey_help () {
   echo "      (DEPRECATED) Downloads the public keys of the github username and adds them to authorized_keys"
   echo ""
   echo "  $(basename "$0") sshkey deletegithubusername <username>"
-  echo "      Deletes all ssh keys related to this user"
+  echo "      (DEPRECATED) Deletes all ssh keys related to this user"
   echo ""
   echo "  $(basename "$0") sshkey addgithubgroup <organization> <team_name> <access_token>"
   echo "      (DEPRECATED) Downloads the public keys of the group members and adds them to authorized_keys"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
Fixes #497 

Added `(DEPRECATED)` to help sshkey under `deletegithubusername`