### PR TITLE
change ssid scan technique to account for hidden ssid (fixes #541)

### DIFF
--- a/modules/bridge.sh
+++ b/modules/bridge.sh
@@ -72,6 +72,7 @@ function bridge {
   then
     {
         echo "network={"
+        echo "  scan_ssid=1"
         echo "  ssid=\"$wifiessid\""
         echo "  key_mgmt=NONE"
         echo "}"
@@ -79,6 +80,7 @@ function bridge {
   else
     {
       echo "network={"
+      echo "  scan_ssid=1"
       echo "  ssid=\"$wifiessid\""
       echo "  psk=\"$wifipassword\""
       echo "}"


### PR DESCRIPTION
Fixes #541 

Changed the `scan_ssid` value from default of `0` to `1`, which allows for scanning of hidden ssids.

**NOTE**
Per https://www.daemon-systems.org/man/wpa_supplicant.conf.5.html: 
`Access points that cloak themselves by not broadcasting their SSID require technique 1, but beware that this scheme can cause scanning to take longer to complete.`

**WIP**
Also change wifi.sh
Possible `treehouses wifi --hidden`?