### PR TITLE
treehouses temperature fahrenheit (fixes #516)

### DIFF
--- a/modules/temperature.sh
+++ b/modules/temperature.sh
@@ -6,9 +6,9 @@ function temperature () {
   number0=${reading:5}
   number=${number0/%??/}
   case "$1" in
-    "")	
-      echo $number	
-      ;;	  
+    "")
+      echo $number
+      ;;
     "fahrenheit")
       fraction=$(echo "scale=2; 9.0/5.0" | bc)
       resultA=$(echo "$number*$fraction" | bc)

--- a/modules/temperature.sh
+++ b/modules/temperature.sh
@@ -10,7 +10,7 @@ function temperature () {
       echo $number
       ;;
     "fahrenheit")
-      fraction=$(echo "scale=2; 9.0/5.0" | bc)
+      fraction=$(echo "scale=1; 9.0/5.0" | bc)
       resultA=$(echo "$number*$fraction" | bc)
       resultB=$(echo "$resultA+32" | bc)
       echo $resultB"°F"

--- a/modules/temperature.sh
+++ b/modules/temperature.sh
@@ -6,19 +6,18 @@ function temperature () {
   number0=${reading:5}
   number=${number0/%??/}
   case "$1" in
-	  
-	  "fahrenheit")
-		  
-		  fahrenheitSymbol="°F"
-		  fraction=$(echo "scale=2; 9.0/5.0" | bc)
-		  resultA=$(echo "$number*$fraction" | bc)
-		  resultB=$(echo "$resultA+32" | bc)
-		  echo $resultB$fahrenheitSymbol
-		  ;;
-	  
-	  "celsius") 
-		  echo $number"°C"
-		  ;;
+    "")	
+      echo $number	
+      ;;	  
+    "fahrenheit")
+      fraction=$(echo "scale=2; 9.0/5.0" | bc)
+      resultA=$(echo "$number*$fraction" | bc)
+      resultB=$(echo "$resultA+32" | bc)
+      echo $resultB"°F"
+      ;;
+    "celsius") 
+      echo $number"°C"
+      ;;
   esac
 }
 

--- a/modules/temperature.sh
+++ b/modules/temperature.sh
@@ -6,25 +6,34 @@ function temperature () {
   number0=${reading:5}
   number=${number0/%??/}
   case "$1" in
-    "") echo $number"°C"
-    ;;
-    "celsius") echo $number
-    ;;
+	  
+	  "fahrenheit")
+		  
+		  fahrenheitSymbol="°F"
+		  fraction=`echo "scale=2; 9.0/5.0" | bc`
+		  resultA=`echo "$number*$fraction" | bc`
+		  resultB=`echo "$resultA+32" | bc`
+		  echo $resultB$fahrenheitSymbol
+		  ;;
+	  
+	  "celsius") 
+		  echo $number"°C"
+		  ;;
   esac
 }
 
 function temperature_help {
   echo ""
-  echo "  Usage: $(basename "$0") temperature <celsius>"
+  echo "  Usage: $(basename "$0") temperature <celsius>/<fahrenheit>"
   echo ""
   echo "  Measures CPU temperature of Raspberry Pi"
   echo ""
   echo "  Example:"
-  echo "  $(basename "$0") temperature"
-  echo ""
-  echo "  60.43°C"
-  echo ""
   echo "  $(basename "$0") temperature celsius"
   echo ""
-  echo "  60.43"  
+  echo "  47.2°C"
+  echo ""
+  echo "  $(basename "$0") temperature fahrenheit"
+  echo ""
+  echo "  116.96°F"  
 }

--- a/modules/temperature.sh
+++ b/modules/temperature.sh
@@ -10,9 +10,9 @@ function temperature () {
 	  "fahrenheit")
 		  
 		  fahrenheitSymbol="°F"
-		  fraction=`echo "scale=2; 9.0/5.0" | bc`
-		  resultA=`echo "$number*$fraction" | bc`
-		  resultB=`echo "$resultA+32" | bc`
+		  fraction=$(echo "scale=2; 9.0/5.0" | bc)
+		  resultA=$(echo "$number*$fraction" | bc)
+		  resultB=$(echo "$resultA+32" | bc)
 		  echo $resultB$fahrenheitSymbol
 		  ;;
 	  

--- a/modules/temperature.sh
+++ b/modules/temperature.sh
@@ -24,7 +24,7 @@ function temperature () {
 
 function temperature_help {
   echo ""
-  echo "  Usage: $(basename "$0") temperature <celsius>/<fahrenheit>"
+  echo "  Usage: $(basename "$0") temperature <celsius|fahrenheit>"
   echo ""
   echo "  Measures CPU temperature of Raspberry Pi"
   echo ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
Fixes #516

Added formula to convert from celsius to fahrenheit and updated help documentation. Users should now enter either "treehouses temperature fahrenheit" or "treehouses temperature celsius."