### PR TITLE
update detectrpi.sh (fixes #565)

### DIFF
--- a/modules/detectrpi.sh
+++ b/modules/detectrpi.sh
@@ -39,6 +39,7 @@ function detectrpi {
   rpimodels["a03111"]="RPI4B" # 1gb
   rpimodels["b03111"]="RPI4B" # 2gb
   rpimodels["c03111"]="RPI4B" # 4gb
+  rpimodels["c03112"]="RPI4B" # 4gb
 
   rpimodel=$(grep Revision /proc/cpuinfo | sed 's/.* //g' | tr -d '\n')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
new hardware id used for my RPi4. I don't know why mine is different but we need to add it. Running treehouse image and got that hardware id. 