### PR TITLE
update bridge.sh (fixes #527, fixes #166)

### DIFF
--- a/modules/bridge.sh
+++ b/modules/bridge.sh
@@ -105,8 +105,8 @@ function bridge {
   echo "bridge" > /etc/network/mode
 
   sync; sync; sync
-  reboot_needed
-  echo "the bridge has been built ;), a reboot is required to apply changes"
+  systemctl isolate rescue; systemctl isolate default
+  echo "the bridge has been built ;), check your wifi and run again if problems"
 }
 
 function bridge_help {

--- a/modules/bridge.sh
+++ b/modules/bridge.sh
@@ -105,7 +105,7 @@ function bridge {
   echo "bridge" > /etc/network/mode
 
   sync; sync; sync
-  systemctl isolate rescue; systemctl isolate default
+  systemctl isolate default
   echo "the bridge has been built ;), check your wifi and run again if problems"
 }
 


### PR DESCRIPTION
So right now we have bridge creating all the configs and etc. necessary to have the OS configure bridge on reboot and fix it that way. But we cannot for what ever reasons figure out some batch of commands to run to do this ourselves. However there is these 2 commands here that seem to relaunch all services. Which is sort of like a reboot but it isn't. This will hopefully prevent SD card damage because of less shutting down? Maybe this will help the longevity of the system's PSU? This should also fix problems with "sync" with files not being written because of a shutdown. I'm not sure on these points but hey we try it anyway. It certainly is "faster".

Need people to test this on all PI systems: RPi 3, 4, etc. 