### PR TITLE
update package.json (fixes #573)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.12.0",
+  "version": "1.12.3",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "email": "vi@treehouses.io",
     "url": "https://treehouses.io"
   },
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/treehouses/cli/issues",
     "email": "vi@treehouses.io"


### PR DESCRIPTION
As per [SPDX](https://spdx.org/licenses/).
```AGPL-3.0-only``` Is valid.
```AGPL-3.0``` Is DEPRECATED.