### PR TITLE
treehouses remote [status|upgrade] added (fixes #590)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,6 @@ camera [on|off|capture]                   enables camera, disables camera, captu
 cron [list|add|delete|deleteall]          adds, deletes a custom cron job or deletes, lists all cron jobs
      [0W|tor|timestamp]                   adds premade cron job (or removes it if already active)
 usb [on|off]                              turns usb ports on or off
-remote [status|upgrade]                   displays current status of the raspberry pi
+remote [status|upgrade]                   helps with treehouses remote android app
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,5 +71,6 @@ camera [on|off|capture]                   enables camera, disables camera, captu
 cron [list|add|delete|deleteall]          adds, deletes a custom cron job or deletes, lists all cron jobs
      [0W|tor|timestamp]                   adds premade cron job (or removes it if already active)
 usb [on|off]                              turns usb ports on or off
+remote [status|upgrade]                   displays current status of the raspberry pi
 ```
 

--- a/_treehouses
+++ b/_treehouses
@@ -40,6 +40,7 @@ _treehouses_complete()
   tor_cmds="start stop add list notice destroy"
   usb_cmds="on off"
   notice_cmds="on off add delete list"
+  remote_cmds="status upgrade"
 
 # upgrade_cmds="" I am not sure whether we should put autocompletion here.
 

--- a/cli.sh
+++ b/cli.sh
@@ -56,6 +56,7 @@ source "$SCRIPTFOLDER/modules/cron.sh"
 source "$SCRIPTFOLDER/modules/discover.sh"
 source "$SCRIPTFOLDER/modules/camera.sh"
 source "$SCRIPTFOLDER/modules/usb.sh"
+source "$SCRIPTFOLDER/moduels/remote.sh"
 
 case $1 in
   expandfs)
@@ -283,6 +284,9 @@ case $1 in
     checkroot
     usb "$2"
     ;;
+  remote)
+    checkroot
+    remote "$2"
   help)
     help "$2"
     ;;

--- a/cli.sh
+++ b/cli.sh
@@ -56,7 +56,7 @@ source "$SCRIPTFOLDER/modules/cron.sh"
 source "$SCRIPTFOLDER/modules/discover.sh"
 source "$SCRIPTFOLDER/modules/camera.sh"
 source "$SCRIPTFOLDER/modules/usb.sh"
-source "$SCRIPTFOLDER/moduels/remote.sh"
+source "$SCRIPTFOLDER/modules/remote.sh"
 
 case $1 in
   expandfs)
@@ -287,6 +287,7 @@ case $1 in
   remote)
     checkroot
     remote "$2"
+    ;;
   help)
     help "$2"
     ;;

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -63,7 +63,7 @@ function help_default {
   echo "   cron [list|add|delete|deleteall]          adds, deletes a custom cron job or deletes, lists all cron jobs"
   echo "        [0W|tor|timestamp]                   adds premade cron job (or removes it if already active)"
   echo "   usb [on|off]                              turns usb ports on or off"
-  echo "   remote [status|upgrade]                   displays current status of the raspberry pi"
+  echo "   remote [status|upgrade]                   helps with treehouses remote android app"
   echo
 }
 

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -63,6 +63,7 @@ function help_default {
   echo "   cron [list|add|delete|deleteall]          adds, deletes a custom cron job or deletes, lists all cron jobs"
   echo "        [0W|tor|timestamp]                   adds premade cron job (or removes it if already active)"
   echo "   usb [on|off]                              turns usb ports on or off"
+  echo "   remote [status|upgrade]                   displays current status of the raspberry pi"
   echo
 }
 

--- a/modules/remote.sh
+++ b/modules/remote.sh
@@ -4,12 +4,6 @@ function remote {
     option="$1"
 
     if [ "$option" = "status" ]; then
-        # source modules/internet.sh
-        # source modules/bluetooth.sh
-        # source modules/image.sh
-        source modules/version.sh
-        # source modules/detectrpi.sh
-
         results=""
         results+="$(internet) "
         results+="$(bluetooth mac) "
@@ -19,9 +13,7 @@ function remote {
 
         echo ${results}
     elif [ "$option" = "upgrade" ]; then
-        source modules/upgrade.sh
-
-        echo "$(upgrade --check)"
+        upgrade --check
     else
         echo "unknown command option"
         echo "usage: $(basename "$0") remote [status | upgrade]"

--- a/modules/remote.sh
+++ b/modules/remote.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+function remote {
+    option="$1"
+
+    if [ "$option" = "status" ]; then
+        # source modules/internet.sh
+        # source modules/bluetooth.sh
+        # source modules/image.sh
+        source modules/version.sh
+        # source modules/detectrpi.sh
+
+        results=""
+        results+="$(internet) "
+        results+="$(bluetooth mac) "
+        results+="$(image) "
+        results+="$(version) "
+        results+="$(detectrpi)"
+
+        echo ${results}
+    elif [ "$option" = "upgrade" ]; then
+        source modules/upgrade.sh
+
+        echo "$(upgrade --check)"
+    else
+        echo "unknown command option"
+        echo "usage: $(basename "$0") remote [status | upgrade]"
+    fi
+}
+
+function remote_help {
+    echo
+    echo "Usage: $(basename "$0") remote [status | upgrade]"
+    echo
+    echo "Returns a string representation of the current status of the Raspberry Pi"
+    echo "Used for Treehouses Remote"
+    echo
+    echo "$(basename "$0") remote status"
+    echo "<internet> <bluetooth mac> <image> <version> <detectrpi>"
+    echo "     │            │           │        │          │"
+    echo "     │            │           │        │          └── model number of rpi"
+    echo "     │            │           │        └───────────── current cli version"
+    echo "     │            │           └────────────────────── current treehouses image version"
+    echo "     │            └────────────────────────────────── bluetooth mac address"
+    echo "     └─────────────────────────────────────────────── internet connection status"
+    echo
+    echo "$(basename "$0") remote upgrade"
+    echo "true if an upgrade is available"
+    echo "false otherwise"
+    echo
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.12.7",
+  "version": "1.12.11",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
Fixes #590

Implements command `treehouses remote status` and `treehouses remote upgrade`
Combined several functions to reduce the possibility of things breaking on the remote app

`treehouses remote status` returns a single string in the form:
`<internet> <bluetooth mac> <image> <version> <detectrpi>`

`treehouses remote upgrade` returns true if an upgrade is available, false otherwise

#### Notes
`treehouses remote upgrade` might be removed?
Seems kind of useless