### PR TITLE
treehouses services fixes/updates (fixes #594)

### DIFF
--- a/modules/services.sh
+++ b/modules/services.sh
@@ -44,7 +44,7 @@ function services {
       docker ps
     elif [ -z "$command" ]; then
       running=$(docker ps --format '{{.Names}}')
-      array=($installed)
+      array=($running)
       results=""
 
       for i in "${array[@]}"

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -14,12 +14,15 @@ function services {
         find_available_services "$service"
       done < <(find "$TEMPLATES/services/"* -maxdepth 1 -type d -print0)
     elif [ -z "$command" ]; then
-      echo $(
-        while IFS= read -r -d '' service
-        do
-          basename "$service"
-        done < <(find "$TEMPLATES/services/"* -maxdepth 1 -type d -print0)
-      )
+      results="Available: "
+
+      while IFS= read -r -d '' service
+      do
+        results+=$(basename "$service")
+        results+=" "
+      done < <(find "$TEMPLATES/services/"* -maxdepth 1 -type d -print0)
+
+      echo ${results}
     fi
   # list all installed services
   elif [ "$service_name" = "installed" ]; then
@@ -28,7 +31,7 @@ function services {
     elif [ -z "$command" ]; then
       installed=$(docker ps -a --format '{{.Names}}')
       array=($installed)
-      results=""
+      results="Installed: "
 
       for i in "${array[@]}"
       do
@@ -45,7 +48,7 @@ function services {
     elif [ -z "$command" ]; then
       running=$(docker ps --format '{{.Names}}')
       array=($running)
-      results=""
+      results="Running: "
 
       for i in "${array[@]}"
       do

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -30,7 +30,7 @@ function services {
       array=($installed)
       results=""
 
-      for i in "${strings[@]}"
+      for i in "${array[@]}"
       do
         results+="${i%%_*}"
         results+=" "
@@ -47,7 +47,7 @@ function services {
       array=($installed)
       results=""
 
-      for i in "${strings[@]}"
+      for i in "${array[@]}"
       do
         results+="${i%%_*}"
         results+=" "

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -7,35 +7,53 @@ function services {
 
   # list all services available to be installed
   if [ "$service_name" = "available" ]; then
-    if [ "$command" = "string" ]; then
+    if [ "$command" = "full" ]; then
+      while IFS= read -r -d '' service
+      do
+        service=$(basename "$service")
+        find_available_services "$service"
+      done < <(find "$TEMPLATES/services/"* -maxdepth 1 -type d -print0)
+    elif [ -z "$command" ]; then
       echo $(
         while IFS= read -r -d '' service
         do
           basename "$service"
         done < <(find "$TEMPLATES/services/"* -maxdepth 1 -type d -print0)
       )
-    else
-      while IFS= read -r -d '' service
-      do
-        service=$(basename "$service")
-        find_available_services "$service"
-      done < <(find "$TEMPLATES/services/"* -maxdepth 1 -type d -print0)
     fi
   # list all installed services
   elif [ "$service_name" = "installed" ]; then
-    if [ "$command" = "string" ]; then
-        installedstring=$(docker ps -a --format '{{.Names}}')
-        echo ${installedstring%%_*}
-    else
+    if [ "$command" = "full" ]; then
       docker ps -a
+    elif [ -z "$command" ]; then
+      installed=$(docker ps -a --format '{{.Names}}')
+      array=($installed)
+      results=""
+
+      for i in "${strings[@]}"
+      do
+        results+="${i%%_*}"
+        results+=" "
+      done
+
+      echo ${results} | tr ' ' '\n' | uniq | xargs
     fi
   # list all running services
   elif [ "$service_name" = "running" ]; then
-    if [ "$command" = "string" ]; then
-        runningstring=$(docker ps --format '{{.Names}}')
-        echo ${runningstring%%_*}
-    else
+    if [ "$command" = "full" ]; then
       docker ps
+    elif [ -z "$command" ]; then
+      running=$(docker ps --format '{{.Names}}')
+      array=($installed)
+      results=""
+
+      for i in "${strings[@]}"
+      do
+        results+="${i%%_*}"
+        results+=" "
+      done
+
+      echo ${results} | tr ' ' '\n' | uniq | xargs
     fi
   else
     if [ -z "$command" ]; then

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -68,29 +68,29 @@ function services {
         up)
           case "$service_name" in
             planet)
-              echo "adding port 80..."
-              treehouses tor add 80
               if [ -f /srv/planet/pwd/credentials.yml ]; then
                 docker-compose -f /srv/planet/planet.yml -f /srv/planet/volumes.yml -f /srv/planet/pwd/credentials.yml -p planet up -d
               else
                 docker-compose -f /srv/planet/planet.yml -f /srv/planet/volumes.yml -p planet up -d
               fi
               echo "planet built and started"
+              echo "adding port 80..."
+              treehouses tor add 80
               ;;
             kolibri)
-              echo "adding port 8080..."
-              treehouses tor add 8080
               bash $TEMPLATES/services/kolibri/kolibri_yml.sh
               echo "yml file created"
 
               docker-compose -f /srv/kolibri/kolibri.yml -p kolibri up -d
               echo "kolibri built and started"
+              echo "adding port 8080..."
+              treehouses tor add 8080
               ;;
             nextcloud)
-              echo "adding port 8081..."
-              treehouses tor add 8081
               docker run --name nextcloud -d -p 8081:80 nextcloud
               echo "nextcloud built and started"
+              echo "adding port 8081..."
+              treehouses tor add 8081
               ;;
             pihole)
               bash $TEMPLATES/services/pihole/pihole_yml.sh
@@ -99,24 +99,26 @@ function services {
               service dnsmasq stop
               docker-compose -f /srv/pihole/pihole.yml -p pihole up -d
               echo "pihole built and started"
+              echo "adding port 8053..."
+              treehouses tor add 8053
               ;;
             moodle)
-              echo "adding port 8082..."
-              treehouses tor add 8082
               bash $TEMPLATES/services/moodle/moodle_yml.sh
               echo "yml file created"
 
               docker-compose -f /srv/moodle/moodle.yml -p moodle up -d
               echo "moodle built and started"
+              echo "adding port 8082..."
+              treehouses tor add 8082
               ;;
             privatebin)
-              echo "adding port 8083..."
-              treehouses tor add 8083
               bash $TEMPLATES/services/privatebin/privatebin_yml.sh
               echo "yml file created"
 
               docker-compose -f /srv/privatebin/privatebin.yml -p privatebin up -d
               echo "privatebin built and started"
+              echo "adding port 8083..."
+              treehouses tor add 8083
               ;;
             *)
               echo "unknown service"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.12.8",
+  "version": "1.12.10",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
* Fixed `treehouses services [available|installed|running]` string output
* Reversed commands:
`treehouses services running string` ->` treehouses services running`
`treehouses services running` ->`treehouses services running full`
* Added `Available: `, `Installed: `, `Running: ` in front of each string output
* Moved tor port adding to the bottom of each `up` function (fixes #594)