### PR TITLE
treehouses services ports & urls (fixes #605) (fixes #606)

### DIFF
--- a/modules/services.sh
+++ b/modules/services.sh
@@ -261,6 +261,33 @@ function services {
           docker ps -a | grep $service_name
           ;;
 
+        # local and tor url
+        url)
+          if [ "$command_option" = "local" ]; then
+            local_url=$(hostname -I | head -n1 | cut -d " " -f1)
+            local_url+=":"
+            local_url+=$(get_port $service_name)
+
+            if [ "$service_name" = "pihole" ]; then
+              local_url+="/admin"
+            fi
+
+            echo $local_url
+          elif [ "$command_option" = "tor" ]; then
+            tor_url=$(tor)
+            tor_url+=":"
+            tor_url+=$(get_port $service_name)
+
+            if [ "$service_name" = "pihole" ]; then
+              tor_url+="/admin"
+            fi
+
+            echo $tor_url
+          else
+            echo "unkown command"
+          fi
+          ;;
+
         *)
           echo "unknown command"
           ;;
@@ -286,6 +313,35 @@ function check_tor {
       treehouses tor add $port
     fi
   fi
+}
+
+# get port number for specified service
+function get_port {
+  service_name="$1"
+
+  case "$service_name" in
+    planet)
+      echo "80"
+      ;;
+    kolibri)
+      echo "8080"
+      ;;
+    nextcloud)
+      echo "8081"
+      ;;
+    pihole)
+      echo "8053"
+      ;;
+    # moodle)
+    #   echo "8082"
+    #   ;;
+    privatebin)
+      echo "8083"
+      ;;
+    *)
+      echo "unknown service"
+      ;;
+  esac
 }
 
 function services_help {

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -63,7 +63,10 @@ function services {
     array=($(services available))
     for i in "${array[@]}"
     do
-      printf "%-10s %20s %-5d\n" "$i" "port" "$(get_port $i)"
+      for j in $(seq 1 "$(get_port $i | wc -l)")
+      do
+        printf "%-10s %20s %-5d\n" "$i" "port" "$(get_port $i | sed -n "$j p")"
+      done
     done
   else
     if [ -z "$command" ]; then

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -269,25 +269,31 @@ function services {
         # local and tor url
         url)
           if [ "$command_option" = "local" ]; then
-            local_url=$(hostname -I | head -n1 | cut -d " " -f1)
-            local_url+=":"
-            local_url+=$(get_port $service_name)
+            for i in $(seq 1 $(get_port $service_name | wc -l))
+            do
+              local_url=$(hostname -I | head -n1 | cut -d " " -f1)
+              local_url+=":"
+              local_url+=$(get_port $service_name | sed -n "$i p")
 
-            if [ "$service_name" = "pihole" ]; then
-              local_url+="/admin"
-            fi
+              if [ "$service_name" = "pihole" ]; then
+                local_url+="/admin"
+              fi
 
-            echo $local_url
+              echo $local_url
+            done
           elif [ "$command_option" = "tor" ]; then
-            tor_url=$(tor)
-            tor_url+=":"
-            tor_url+=$(get_port $service_name)
+            for i in $(seq 1 $(get_port $service_name | wc -l))
+            do
+              tor_url=$(tor)
+              tor_url+=":"
+              tor_url+=$(get_port $service_name | sed -n "$i p")
 
-            if [ "$service_name" = "pihole" ]; then
-              tor_url+="/admin"
-            fi
+              if [ "$service_name" = "pihole" ]; then
+                tor_url+="/admin"
+              fi
 
-            echo $tor_url
+              echo $tor_url
+            done
           elif [ "$command_option" = "both" ]; then
             services $service_name url local
             services $service_name url tor
@@ -335,6 +341,7 @@ function get_port {
   case "$service_name" in
     planet)
       echo "80"
+      echo "2200"
       ;;
     kolibri)
       echo "8080"

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -347,6 +347,9 @@ function get_port {
     privatebin)
       echo "8083"
       ;;
+    portainer)
+      echo "9000"
+      ;;
     *)
       echo "unknown service"
       ;;

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -63,10 +63,13 @@ function services {
     array=($(services available))
     for i in "${array[@]}"
     do
+      port_string=""
       for j in $(seq 1 "$(get_port $i | wc -l)")
       do
-        printf "%-10s %20s %-5d\n" "$i" "port" "$(get_port $i | sed -n "$j p")"
+        port_string+=$(get_port $i | sed -n "$j p")
+        port_string+=" "
       done
+      printf "%-10s %20s %-5s\n" "$i" "port" "$(echo $port_string | xargs | sed -e 's/ /, /g')"
     done
   else
     if [ -z "$command" ]; then

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -288,8 +288,12 @@ function services {
             fi
 
             echo $tor_url
+          elif [ "$command_option" = "both" ]; then
+            services $service_name url local
+            services $service_name url tor
           else
-            echo "unkown command"
+            echo "unknown command"
+            echo "usage: $(basename "$0") services <service_name> url [local | tor | both]"
           fi
           ;;
 
@@ -370,19 +374,19 @@ function services_help {
   echo "  Portainer"
   echo
   echo "commands:"
-  echo "  available                   lists all available services"
-  echo "  installed                   lists all installed services"
-  echo "  running                     lists all running services"
-  echo "  ports                       lists all ports used by services"
-  echo "  up                          builds and starts the service"
-  echo "  down                        stops and removes the service"
-  echo "  start                       starts the service"
-  echo "  stop                        stops the service"
-  echo "  autorun                     outputs true if the service is set to autorun or false otherwise"
-  echo "  autorun [true | false]      sets the service autorun to true | false"
-  echo "  ps                          outputs the containers related to the service"
-  echo "  url [local | tor]           outputs the local | tor address for the service"
-  echo "  <service> port              outputs the port number for the service"
+  echo "  available                           lists all available services"
+  echo "  installed                           lists all installed services"
+  echo "  running                             lists all running services"
+  echo "  ports                               lists all ports used by services"
+  echo "  up                                  builds and starts the service"
+  echo "  down                                stops and removes the service"
+  echo "  start                               starts the service"
+  echo "  stop                                stops the service"
+  echo "  autorun                             outputs true if the service is set to autorun or false otherwise"
+  echo "  autorun [true | false]              sets the service autorun to true | false"
+  echo "  ps                                  outputs the containers related to the service"
+  echo "  <service_name> url [local | tor]    outputs the local | tor address for the service"
+  echo "  <service_name> port                 outputs the port number for the service"
   echo
   echo "examples:"
   echo

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -381,6 +381,8 @@ function services_help {
   echo "  autorun                     outputs true if the service is set to autorun or false otherwise"
   echo "  autorun [true | false]      sets the service autorun to true | false"
   echo "  ps                          outputs the containers related to the service"
+  echo "  url [local | tor]           outputs the local | tor address for the service"
+  echo "  <service> port              outputs the port number for the service"
   echo
   echo "examples:"
   echo

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -269,7 +269,7 @@ function services {
         # local and tor url
         url)
           if [ "$command_option" = "local" ]; then
-            for i in $(seq 1 $(get_port $service_name | wc -l))
+            for i in $(seq 1 "$(get_port $service_name | wc -l)")
             do
               local_url=$(hostname -I | head -n1 | cut -d " " -f1)
               local_url+=":"
@@ -282,7 +282,7 @@ function services {
               echo $local_url
             done
           elif [ "$command_option" = "tor" ]; then
-            for i in $(seq 1 $(get_port $service_name | wc -l))
+            for i in $(seq 1 "$(get_port $service_name | wc -l)")
             do
               tor_url=$(tor)
               tor_url+=":"

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -60,12 +60,11 @@ function services {
     fi
   # list all ports used by services
   elif [ "$service_name" = "ports" ]; then
-    echo "Planet                port 80"
-    echo "Kolibri               port 8080"
-    echo "Nextcloud             port 8081"
-    echo "Pi-hole               port 8053"
-    # echo "Moodle                port 8082"
-    echo "PrivateBin            port 8083"
+    array=($(services available))
+    for i in "${array[@]}"
+    do
+      printf "%-10s %20s %-5d\n" "$i" "port" "$(get_port $i)"
+    done
   else
     if [ -z "$command" ]; then
       echo "no command given"
@@ -332,9 +331,9 @@ function get_port {
     pihole)
       echo "8053"
       ;;
-    # moodle)
-    #   echo "8082"
-    #   ;;
+    moodle)
+      echo "8082"
+      ;;
     privatebin)
       echo "8083"
       ;;

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -287,6 +287,10 @@ function services {
           fi
           ;;
 
+        port)
+          get_port $service_name
+          ;;
+
         *)
           echo "unknown command"
           ;;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.12.18",
+  "version": "1.12.21",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
Fixes #605
Fixes #606

* Added helper function for getting port numbers of specific services
`function get_port`
* Added functionality to get port numbers of individual services
`treehouses services planet port`
* Reworked functionality for getting port numbers of all services
`treehouses services ports`
* Added functionality to get urls (local or tor) for specific services
`treehouses services planet url local`
`treehouses services planet url tor`