### PR TITLE
treehouses tor start port check (fixes #612)

### DIFF
--- a/modules/tor.sh
+++ b/modules/tor.sh
@@ -4,6 +4,12 @@ function tor {
   check_missing_packages "tor" "curl"
 
   if { [ ! -d "/var/lib/tor/treehouses" ] || [ ! -f "/var/lib/tor/treehouses/hostname" ]; } && [ "$1" != "start" ] && [ "$1" != "add" ]; then
+    if [ -z $(grep -Poi "^HiddenServicePort \\K(.*) 127.0.0.1:(.*)\\b" /etc/tor/torrc | tac | sed -r 's/(.*?)127.0.0.1:(.*?)/\1 <=> \2/g') ]; then
+      echo "Error: there are no tor ports added."
+      echo "'$(basename "$0") add [localPort]' to add a port and be able to use the service"
+      exit 1
+    fi
+
     echo "Error: the tor service has not been configured."
     echo "Run '$(basename "$0") tor start' to configure it."
     echo "Or '$(basename "$0") add [localPort]' to add a port and be able to use the service"

--- a/modules/tor.sh
+++ b/modules/tor.sh
@@ -7,12 +7,10 @@ function tor {
     if [ -z "$(grep -Poi "^HiddenServicePort \\K(.*) 127.0.0.1:(.*)\\b" /etc/tor/torrc | tac | sed -r 's/(.*?)127.0.0.1:(.*?)/\1 <=> \2/g')" ]; then
       echo "Error: there are no tor ports added."
       echo "'$(basename "$0") add [localPort]' to add a port and be able to use the service"
-      exit 1
+    elif
+      echo "Error: the tor service has not been configured."
+      echo "Run '$(basename "$0") tor start' to configure it."
     fi
-
-    echo "Error: the tor service has not been configured."
-    echo "Run '$(basename "$0") tor start' to configure it."
-    echo "Or '$(basename "$0") add [localPort]' to add a port and be able to use the service"
     exit 1
   fi
 

--- a/modules/tor.sh
+++ b/modules/tor.sh
@@ -4,7 +4,7 @@ function tor {
   check_missing_packages "tor" "curl"
 
   if { [ ! -d "/var/lib/tor/treehouses" ] || [ ! -f "/var/lib/tor/treehouses/hostname" ]; } && [ "$1" != "start" ] && [ "$1" != "add" ]; then
-    if [ -z $(grep -Poi "^HiddenServicePort \\K(.*) 127.0.0.1:(.*)\\b" /etc/tor/torrc | tac | sed -r 's/(.*?)127.0.0.1:(.*?)/\1 <=> \2/g') ]; then
+    if [ -z "$(grep -Poi "^HiddenServicePort \\K(.*) 127.0.0.1:(.*)\\b" /etc/tor/torrc | tac | sed -r 's/(.*?)127.0.0.1:(.*?)/\1 <=> \2/g')" ]; then
       echo "Error: there are no tor ports added."
       echo "'$(basename "$0") add [localPort]' to add a port and be able to use the service"
       exit 1

--- a/modules/tor.sh
+++ b/modules/tor.sh
@@ -7,7 +7,7 @@ function tor {
     if [ -z "$(grep -Poi "^HiddenServicePort \\K(.*) 127.0.0.1:(.*)\\b" /etc/tor/torrc | tac | sed -r 's/(.*?)127.0.0.1:(.*?)/\1 <=> \2/g')" ]; then
       echo "Error: there are no tor ports added."
       echo "'$(basename "$0") add [localPort]' to add a port and be able to use the service"
-    elif
+    else
       echo "Error: the tor service has not been configured."
       echo "Run '$(basename "$0") tor start' to configure it."
     fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.12.18",
+  "version": "1.12.20",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
Fixes #612

Added a check to see if there are any tor ports added.

You can test by running:
`./cli.sh tor destroy` warning: will remove all your tor ports
`./cli.sh tor start`
`./cli.sh tor status` will show an error message like below:
```
Error: there are no tor ports added.
'cli.sh add [localPort]' to add a port and be able to use the service
```

Adding any port (`./cli.sh tor add <port>`) will then allow normal usage.