### PR TITLE
update services.sh (fixes #628)

### DIFF
--- a/modules/services.sh
+++ b/modules/services.sh
@@ -319,6 +319,8 @@ function services {
               echo "Swarm clusters).\""
               ;;
           esac
+          ;;
+          
         # local and tor url
         url)
           if [ "$command_option" = "local" ]; then


### PR DESCRIPTION
Fixed small typo in services.sh so that `treehouses services <service name> info` functions correctly.