### PR TITLE
treehouses services with check_space (fixes #621)

### DIFF
--- a/modules/services.sh
+++ b/modules/services.sh
@@ -385,7 +385,7 @@ function check_space {
   free_space=$(df -Ph /var/lib/docker | awk 'END {print $4}')
   free_space=$(echo $free_space | numfmt --from=iec)
 
-  if (( $image_size > $free_space )); then
+  if (( image_size > free_space )); then
     echo "image size:" $image_size
     echo "free space:" $free_space
     echo "not enough free space"

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -382,8 +382,7 @@ function find_available_services {
 
 function check_space {
   image_size=$(curl -s -H "Authorization: JWT " "https://hub.docker.com/v2/repositories/${1}/tags/?page_size=100" | jq -r '.results[] | select(.name == "latest") | .images[0].size')
-  free_space=$(df -Ph /var/lib/docker | awk 'END {print $4}')
-  free_space=$(echo $free_space | numfmt --from=iec)
+  free_space=$(df -Ph /var/lib/docker | awk 'END {print $4}' | numfmt --from=iec)
 
   if (( image_size > free_space )); then
     echo "image size:" $image_size

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -99,10 +99,8 @@ function services {
               ;;
             nextcloud)
               check_space "library/nextcloud"
-
               bash $TEMPLATES/services/nextcloud/nextcloud_yml.sh
               echo "yml file created"
-
               docker-compose -f /srv/nextcloud/nextcloud.yml -p nextcloud up -d
               echo "nextcloud built and started"
               check_tor "8081"
@@ -136,7 +134,6 @@ function services {
               check_space "portainer/portainer"
               bash $TEMPLATES/services/portainer/portainer_yml.sh
               echo "yml file created"
-
               docker-compose -f /srv/portainer/portainer.yml -p portainer up -d
               echo "portainer built and started"
               check_tor "9000"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.13.2",
+  "version": "1.13.10",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
Fixes #621

Adds a check_space function to check if there is enough free space on disk for the new service before pulling.

One problem is that you can only get the compressed image size which will obviously get larger when uncompressed.

An alternative would be to try to pull the image and when Docker throws an error catch that error instead of trying to check free space before pulling.