### PR TITLE
treehouses services ntopng added (fixes #618)

### DIFF
--- a/modules/services.sh
+++ b/modules/services.sh
@@ -331,6 +331,8 @@ function services {
               echo "a network traffic probe that monitors network usage. ntopng is"
               echo "based on libpcap and it has been written in a portable way in order"
               echo "to virtually run on every Unix platform, MacOSX and on Windows as well."
+              echo "Educational users can obtain commercial products at no cost please see here:"
+              echo "https://www.ntop.org/support/faq/do-you-charge-universities-no-profit-and-research/"
               ;;
           esac
           ;;

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -324,7 +324,7 @@ function services {
               echo "based on libpcap and it has been written in a portable way in order"
               echo "to virtually run on every Unix platform, MacOSX and on Windows as well."
               echo "Educational users can obtain commercial products at no cost please see here:"
-              echo "https://www.ntop.org/support/faq/do-you-charge-universities-no-profit-and-research/"
+              echo "https://www.ntop.org/support/faq/do-you-charge-universities-no-profit-and-research/\""
               ;;
           esac
           ;;

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -132,6 +132,12 @@ function services {
               echo "portainer built and started"
               check_tor "9000"
               ;;
+            ntopng)            
+              docker volume create ntopng_data
+              docker run --name ntopng -d -p 8090:8090 -v /var/run/docker.sock:/var/run/docker.sock -v ntopng_data:/data jonbackhaus/ntopng --http-port=8090
+              echo "ntopng built and started"
+              check_tor "8090"
+              ;;
             *)
               echo "unknown service"
               ;;
@@ -148,7 +154,7 @@ function services {
                 echo "${service_name} stopped and removed"
               fi
               ;;
-            nextcloud|portainer)
+            nextcloud|portainer|ntopng)
               docker stop $service_name
               docker rm $service_name
               echo "${service_name} stopped and removed"
@@ -169,7 +175,7 @@ function services {
                 echo "service not found"
               fi
               ;;
-            nextcloud|portainer)
+            nextcloud|portainer|ntopng)
               docker start $service_name
               echo "${service_name} started"
               ;;
@@ -189,7 +195,7 @@ function services {
                 echo "service not found"
               fi
               ;;
-            nextcloud|portainer)
+            nextcloud|portainer|ntopng)
               docker stop $service_name
               echo "${service_name} stopped"
               ;;
@@ -318,6 +324,14 @@ function services {
               echo "easily manage your different Docker environments (Docker hosts or"
               echo "Swarm clusters).\""
               ;;
+            ntopng)
+              echo "https://github.com/ntop/ntopng"
+              echo                 
+              echo "\"ntopng is the next generation version of the original ntop,"
+              echo "a network traffic probe that monitors network usage. ntopng is"
+              echo "based on libpcap and it has been written in a portable way in order"
+              echo "to virtually run on every Unix platform, MacOSX and on Windows as well."
+              ;;
           esac
           ;;
 
@@ -416,6 +430,9 @@ function get_port {
     portainer)
       echo "9000"
       ;;
+    ntopng)
+      echo "8090"
+      ;;
     *)
       echo "unknown service"
       ;;
@@ -433,6 +450,7 @@ function services_help {
   # echo "  Moodle"
   echo "  PrivateBin"
   echo "  Portainer"
+  echo "  Ntopng"
   echo
   echo
   echo "Top-Level Commands:"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.13.7",
+  "version": "1.13.11",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {

--- a/templates/services/ntopng/ntopng_autorun
+++ b/templates/services/ntopng/ntopng_autorun
@@ -1,0 +1,7 @@
+ntopng_autorun=true
+
+if [ "ntopng_autorun" = true ]; then
+  docker volume create ntopng_data
+  docker run --name ntopng -d -p 8090:8090 -v /var/run/docker.sock:/var/run/docker.sock -v ntopng_data:/data jonbackhaus/ntopng --http-port=8090
+fi
+


### PR DESCRIPTION
Fixes #618 
- https://github.com/ntop/ntopng
![](https://i.imgur.com/LiWIFMp.png)

- The only problems i see with this is after a while the license expires (10mins? or 15mins?) 
- At that time the functionality regresses and it throws a plugin error
- Don't know what to do to fix that. Maybe delete the plugin. 
- There isn't really any docker images available to test for this except 1. 
- The rest are 4 years+ old and usually aren't for arm. 
`Important Information: Please Read
The licenses you can buy from this shop are valid only for binary packages that you can find at packages.ntop.org.
Licenses cannot be used with custom-built packages or on operating systems other than those listed at the packages site.
We will provide 5 days of installation support from the date of purchase, where you can ask us questions limited to: how to start the tool on your system, or install the packages.
If you have requests about how to operate the tool or need anything beside ure installation you need to buy a support ticket.
All software products will be immediately available for download after completing your order.
All software products will include one year maintenance and free access to updates.
For each successful transaction you will receive a valid tax invoice that proves your purchase and can be used for claiming your expenses.
If you want to renew maintenance for products you have purchased previously, please read this document for more information.
Educational users can obtain commercial products at no cost.
In addition to the online shop, you can also contact one of our resellers.`
https://www.ntop.org/support/faq/do-you-charge-universities-no-profit-and-research/
Ntop provides license for educational use for non profits. This is our best route.