### PR TITLE
treehouses services url with networkmode info (fixes #649)

### DIFF
--- a/modules/services.sh
+++ b/modules/services.sh
@@ -326,7 +326,7 @@ function services {
           if [ "$command_option" = "local" ]; then
             for i in $(seq 1 "$(get_port $service_name | wc -l)")
             do
-              local_url=$(treehouses networkmode info | grep -oP -m1 '(?<=ip: ).*?(?=,)')
+              local_url=$(networkmode info | grep -oP -m1 '(?<=ip: ).*?(?=,)')
               local_url+=":"
               local_url+=$(get_port $service_name | sed -n "$i p")
 

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -326,7 +326,7 @@ function services {
           if [ "$command_option" = "local" ]; then
             for i in $(seq 1 "$(get_port $service_name | wc -l)")
             do
-              local_url=$(hostname -I | head -n1 | cut -d " " -f1)
+              local_url=$(treehouses networkmode info | grep -oP -m1 '(?<=ip: ).*?(?=,)')
               local_url+=":"
               local_url+=$(get_port $service_name | sed -n "$i p")
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.13.5",
+  "version": "1.13.9",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
Fixes #649

Changed from using `hostname` to using `treehouses networkmode` to get IP address when creating local url for services.