### PR TITLE
treehouses services error handling

### DIFF
--- a/modules/services.sh
+++ b/modules/services.sh
@@ -382,11 +382,11 @@ function docker_compose_up {
 # tor status and port check
 function check_tor {
   port="$1"
-  if [ "$(treehouses tor status)" = "active" ]; then
+  if [ "$(tor status)" = "active" ]; then
     echo "tor active"
-    if ! treehouses tor list | grep -w $port; then
+    if ! tor list | grep -w $port; then
       echo "adding port ${port}"
-      treehouses tor add $port
+      tor add $port
     fi
   fi
 }

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -81,60 +81,51 @@ function services {
           case "$service_name" in
             planet)
               if [ -f /srv/planet/pwd/credentials.yml ]; then
-                docker-compose -f /srv/planet/planet.yml -f /srv/planet/volumes.yml -f /srv/planet/pwd/credentials.yml -p planet up -d
+                if docker-compose -f /srv/planet/planet.yml -f /srv/planet/volumes.yml -f /srv/planet/pwd/credentials.yml -p planet up -d ; then
+                  echo "planet built and started"
+                else
+                  echo "error building planet"
+                  exit 1
+                fi
               else
-                docker-compose -f /srv/planet/planet.yml -f /srv/planet/volumes.yml -p planet up -d
+                if docker-compose -f /srv/planet/planet.yml -f /srv/planet/volumes.yml -p planet up -d ; then
+                  echo "planet built and started"
+                else
+                  echo "error building planet"
+                  exit 1
+                fi
               fi
-              echo "planet built and started"
               check_tor "80"
               ;;
             kolibri)
-              bash $TEMPLATES/services/kolibri/kolibri_yml.sh
-              echo "yml file created"
-
-              docker-compose -f /srv/kolibri/kolibri.yml -p kolibri up -d
-              echo "kolibri built and started"
+              create_yml "kolibri"
+              docker_compose_up "kolibri"
               check_tor "8080"
               ;;
             nextcloud)
-              bash $TEMPLATES/services/nextcloud/nextcloud_yml.sh
-              echo "yml file created"
-
-              docker-compose -f /srv/nextcloud/nextcloud.yml -p nextcloud up -d
-              echo "nextcloud built and started"
+              create_yml "nextcloud"
+              docker_compose_up "nextcloud"
               check_tor "8081"
               ;;
             pihole)
-              bash $TEMPLATES/services/pihole/pihole_yml.sh
-              echo "yml file created"
-
+              create_yml "pihole"
               service dnsmasq stop
-              docker-compose -f /srv/pihole/pihole.yml -p pihole up -d
-              echo "pihole built and started"
+              docker_compose_up "pihole"
               check_tor "8053"
               ;;
             moodle)
-              bash $TEMPLATES/services/moodle/moodle_yml.sh
-              echo "yml file created"
-
-              docker-compose -f /srv/moodle/moodle.yml -p moodle up -d
-              echo "moodle built and started"
+              create_yml "moodle"
+              docker_compose_up "moodle"
               check_tor "8082"
               ;;
             privatebin)
-              bash $TEMPLATES/services/privatebin/privatebin_yml.sh
-              echo "yml file created"
-
-              docker-compose -f /srv/privatebin/privatebin.yml -p privatebin up -d
-              echo "privatebin built and started"
+              create_yml "privatebin"
+              docker_compose_up "privatebin"
               check_tor "8083"
               ;;
             portainer)
-              bash $TEMPLATES/services/portainer/portainer_yml.sh
-              echo "yml file created"
-
-              docker-compose -f /srv/portainer/portainer.yml -p portainer up -d
-              echo "portainer built and started"
+              create_yml "portainer"
+              docker_compose_up "portainer"
               check_tor "9000"
               ;;
             *)
@@ -367,6 +358,25 @@ function find_available_services {
   service_name="$1"
   available_formats=$(find "$TEMPLATES/services/$service/"* -exec basename {} \; | tr '\n' "|" | sed '$s/|$//')
   echo "$service [$available_formats]"
+}
+
+function create_yml {
+  if bash $TEMPLATES/services/${1}/${1}_yml.sh ; then
+    echo "yml file created"
+  else
+    echo "error creating yml file"
+    exit 1
+  fi
+  
+}
+
+function docker_compose_up {
+  if docker-compose -f /srv/${1}/${1}.yml -p ${1} up -d ; then
+    echo "${1} built and started"
+  else
+    echo "error building ${1}"
+    exit 1
+  fi
 }
 
 # tor status and port check

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -383,7 +383,6 @@ function find_available_services {
   echo "$service [$available_formats]"
 }
 
-
 function create_yml {
   if bash $TEMPLATES/services/${1}/${1}_yml.sh ; then
     echo "yml file created"

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -367,7 +367,6 @@ function create_yml {
     echo "error creating yml file"
     exit 1
   fi
-  
 }
 
 function docker_compose_up {

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -397,6 +397,9 @@ function docker_compose_up {
     echo "${1} built and started"
   else
     echo "error building ${1}"
+    exit 1
+  fi
+}
 
 function check_space {
   image_size=$(curl -s -H "Authorization: JWT " "https://hub.docker.com/v2/repositories/${1}/tags/?page_size=100" | jq -r '.results[] | select(.name == "latest") | .images[0].size')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.13.11",
+  "version": "1.13.12",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
Added error handling for creating yml files and running docker-compose up commands.
Created functions (`create_yml` and `docker_compose_up`) to facilitate error handling.

Considering adding error handling for the other docker-compose commands (`down`, `start`, `stop`)?