### PR TITLE
remove shebang from sources (fixes #666)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,3 +12,5 @@ engines:
         enabled: false
       SC2154:
         enabled: false
+      SC2149:
+        enabled: false

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,5 +12,5 @@ engines:
         enabled: false
       SC2154:
         enabled: false
-      SC2149:
+      SC2148:
         enabled: false

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,4 +14,3 @@ engines:
         enabled: false
       SC2148:
         enabled: false
-        

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,3 +14,4 @@ engines:
         enabled: false
       SC2148:
         enabled: false
+        

--- a/modules/ap.sh
+++ b/modules/ap.sh
@@ -1,4 +1,3 @@
-
 function ap {
   mode=$(clean_var "$1")
   essid=$(clean_var "$2")

--- a/modules/ap.sh
+++ b/modules/ap.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function ap {
   mode=$(clean_var "$1")

--- a/modules/apchannel.sh
+++ b/modules/apchannel.sh
@@ -1,4 +1,3 @@
-
 function apchannel {
   new_channel="$1"
   if [ "$(networkmode)" == "bridge" ] || [ "$(networkmode)" == "ap local" ] || [ "$(networkmode)" == "ap internet" ]; then

--- a/modules/apchannel.sh
+++ b/modules/apchannel.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function apchannel {
   new_channel="$1"

--- a/modules/aphidden.sh
+++ b/modules/aphidden.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function aphidden {
   mode=$(clean_var "$1")

--- a/modules/aphidden.sh
+++ b/modules/aphidden.sh
@@ -1,4 +1,3 @@
-
 function aphidden {
   mode=$(clean_var "$1")
   essid=$(clean_var "$2")

--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function bluetooth {
   status=$1

--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -1,4 +1,3 @@
-
 function bluetooth {
   status=$1
 

--- a/modules/bluetoothid.sh
+++ b/modules/bluetoothid.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function bluetoothid () {
   #check if bluetooth has an id

--- a/modules/bluetoothid.sh
+++ b/modules/bluetoothid.sh
@@ -1,4 +1,3 @@
-
 function bluetoothid () {
   #check if bluetooth has an id
   btidfile=/etc/bluetooth-id

--- a/modules/bootoption.sh
+++ b/modules/bootoption.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function bootoption {
   option="$1"

--- a/modules/bootoption.sh
+++ b/modules/bootoption.sh
@@ -1,4 +1,3 @@
-
 function bootoption {
   option="$1"
   if [ "$option" = "console" ]; then

--- a/modules/bridge.sh
+++ b/modules/bridge.sh
@@ -1,4 +1,3 @@
-
 function bridge {
   case $(detectrpi) in
     RPI3B|RPIZW|RPI3B+|RPI3A+|RPI4B)

--- a/modules/bridge.sh
+++ b/modules/bridge.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function bridge {
   case $(detectrpi) in

--- a/modules/burn.sh
+++ b/modules/burn.sh
@@ -1,4 +1,3 @@
-
 function burn {
     device="$1"
     if [ -z "$device" ]; then

--- a/modules/burn.sh
+++ b/modules/burn.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function burn {
     device="$1"

--- a/modules/button.sh
+++ b/modules/button.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # treehouses button off                        => disables button ~ it does nothing
 # treehouses button bluetooth                  => bluetooth will be ON when cable is off and OFF when cable is on
 

--- a/modules/button.sh
+++ b/modules/button.sh
@@ -1,6 +1,5 @@
 # treehouses button off                        => disables button ~ it does nothing
 # treehouses button bluetooth                  => bluetooth will be ON when cable is off and OFF when cable is on
-
 function button {
   mode=$1
 

--- a/modules/camera.sh
+++ b/modules/camera.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function camera {
   directory="/home/pi/Pictures/"

--- a/modules/camera.sh
+++ b/modules/camera.sh
@@ -1,4 +1,3 @@
-
 function camera {
   directory="/home/pi/Pictures/"
   timestamp=$(date +"%Y%m%d-%H%M%S")

--- a/modules/clone.sh
+++ b/modules/clone.sh
@@ -1,4 +1,3 @@
-
 function clone {
   device="$1"
   if [ -z "$device" ]; then

--- a/modules/clone.sh
+++ b/modules/clone.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function clone {
   device="$1"

--- a/modules/config.sh
+++ b/modules/config.sh
@@ -1,4 +1,3 @@
-
 # config constants
 CONFIGFILE=/etc/treehouses.conf
 BASENAME=$(basename "$0")

--- a/modules/config.sh
+++ b/modules/config.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 # config constants
 CONFIGFILE=/etc/treehouses.conf

--- a/modules/container.sh
+++ b/modules/container.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function container {
 if [ "$1" == "docker" ] ; then

--- a/modules/container.sh
+++ b/modules/container.sh
@@ -1,4 +1,3 @@
-
 function container {
 if [ "$1" == "docker" ] ; then
     container_docker;

--- a/modules/coralenv.sh
+++ b/modules/coralenv.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function coralenv {
   param=$1

--- a/modules/coralenv.sh
+++ b/modules/coralenv.sh
@@ -1,4 +1,3 @@
-
 function coralenv {
   param=$1
   cronjob='@reboot nohup python3 /usr/lib/python3/dist-packages/coral/enviro/enviro_demo.py &>"$LOGFILE" &'

--- a/modules/cron.sh
+++ b/modules/cron.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function cron {
   options="$1"

--- a/modules/cron.sh
+++ b/modules/cron.sh
@@ -1,4 +1,3 @@
-
 function cron {
   options="$1"
   case "$options" in

--- a/modules/default.sh
+++ b/modules/default.sh
@@ -1,4 +1,3 @@
-
 function default {
   if [ "$1" == "notice" ] ; then
     default_notice

--- a/modules/default.sh
+++ b/modules/default.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function default {
   if [ "$1" == "notice" ] ; then

--- a/modules/detect.sh
+++ b/modules/detect.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function detect {
   if [ "$(detectrpi)" != "nonrpi" ]; then

--- a/modules/detect.sh
+++ b/modules/detect.sh
@@ -1,4 +1,3 @@
-
 function detect {
   if [ "$(detectrpi)" != "nonrpi" ]; then
     echo "rpi $(detectrpi)"

--- a/modules/detectrpi.sh
+++ b/modules/detectrpi.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function detectrpi {
   declare -A rpimodels

--- a/modules/detectrpi.sh
+++ b/modules/detectrpi.sh
@@ -1,4 +1,3 @@
-
 function detectrpi {
   declare -A rpimodels
   rpimodels["Beta"]="BETA"

--- a/modules/discover.sh
+++ b/modules/discover.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function discover {
   check_missing_packages "nmap"

--- a/modules/discover.sh
+++ b/modules/discover.sh
@@ -1,4 +1,3 @@
-
 function discover {
   check_missing_packages "nmap"
 

--- a/modules/ethernet.sh
+++ b/modules/ethernet.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function ethernet {
 

--- a/modules/ethernet.sh
+++ b/modules/ethernet.sh
@@ -1,4 +1,3 @@
-
 function ethernet {
 
   if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ]; then

--- a/modules/expandfs.sh
+++ b/modules/expandfs.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function expandfs () {
   # expandfs is way too complex, it should be handled by raspi-config

--- a/modules/expandfs.sh
+++ b/modules/expandfs.sh
@@ -1,4 +1,3 @@
-
 function expandfs () {
   # expandfs is way too complex, it should be handled by raspi-config
   raspi-config --expand-rootfs >"$LOGFILE" 2>"$LOGFILE"

--- a/modules/feedback.sh
+++ b/modules/feedback.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 token="adfab56b2f10b85f94db25f18e51a4b465dbd670"
 channel="https://api.gitter.im/v1/rooms/5ba5af3cd73408ce4fa8fcfb/chatMessages"

--- a/modules/feedback.sh
+++ b/modules/feedback.sh
@@ -1,4 +1,3 @@
-
 token="adfab56b2f10b85f94db25f18e51a4b465dbd670"
 channel="https://api.gitter.im/v1/rooms/5ba5af3cd73408ce4fa8fcfb/chatMessages"
 # set on ../templates/network/tor_report.sh

--- a/modules/globals.sh
+++ b/modules/globals.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function start_service {
   if [ "$(systemctl is-active "$1" 2>"$LOGFILE")" = "inactive" ]

--- a/modules/globals.sh
+++ b/modules/globals.sh
@@ -1,4 +1,3 @@
-
 function start_service {
   if [ "$(systemctl is-active "$1" 2>"$LOGFILE")" = "inactive" ]
   then

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -1,4 +1,3 @@
-
 function help_default {
   echo "Usage: $BASENAME"
   echo

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function help_default {
   echo "Usage: $BASENAME"

--- a/modules/image.sh
+++ b/modules/image.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function image {
     cat /boot/version.txt

--- a/modules/image.sh
+++ b/modules/image.sh
@@ -1,4 +1,3 @@
-
 function image {
     cat /boot/version.txt
 }

--- a/modules/internet.sh
+++ b/modules/internet.sh
@@ -1,4 +1,3 @@
-
 function internet {
   if wget -q --spider -T 3 --no-check-certificate https://www.google.com; then
     echo "true"

--- a/modules/internet.sh
+++ b/modules/internet.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function internet {
   if wget -q --spider -T 3 --no-check-certificate https://www.google.com; then

--- a/modules/led.sh
+++ b/modules/led.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function led {
   color="$1"

--- a/modules/led.sh
+++ b/modules/led.sh
@@ -1,4 +1,3 @@
-
 function led {
   color="$1"
   trigger="$2"

--- a/modules/locale.sh
+++ b/modules/locale.sh
@@ -1,4 +1,3 @@
-
 function locale {
   locale="$1"
   if [ -z "$locale" ];

--- a/modules/locale.sh
+++ b/modules/locale.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function locale {
   locale="$1"

--- a/modules/log.sh
+++ b/modules/log.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # uses logger command to log to /var/log/syslog 
 # logit "text" "whether or not to write to screen" "logging level"
 # e.g. logit "i logged some text"

--- a/modules/memory.sh
+++ b/modules/memory.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function memory_total() {
   option=$1

--- a/modules/memory.sh
+++ b/modules/memory.sh
@@ -1,4 +1,3 @@
-
 function memory_total() {
   option=$1
   case $option in 

--- a/modules/networkmode.sh
+++ b/modules/networkmode.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function networkmode {
   network_mode="default"

--- a/modules/networkmode.sh
+++ b/modules/networkmode.sh
@@ -1,4 +1,3 @@
-
 function networkmode {
   network_mode="default"
   if [ -f "/etc/network/mode" ]; then

--- a/modules/ntp.sh
+++ b/modules/ntp.sh
@@ -1,4 +1,3 @@
-
 function ntp {
   status="$1"
 

--- a/modules/ntp.sh
+++ b/modules/ntp.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function ntp {
   status="$1"

--- a/modules/openvpn.sh
+++ b/modules/openvpn.sh
@@ -1,4 +1,3 @@
-
 function openvpn {
   command="$1"
 

--- a/modules/openvpn.sh
+++ b/modules/openvpn.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function openvpn {
   command="$1"

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -1,4 +1,3 @@
-
 function password () {
   echo "pi:$1" | chpasswd
   echo "Success: the password has been changed"

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function password () {
   echo "pi:$1" | chpasswd

--- a/modules/rebootneeded.sh
+++ b/modules/rebootneeded.sh
@@ -1,4 +1,3 @@
-
 function rebootneeded {
   if [ -f "/etc/reboot-needed" ]; then
     echo "true";

--- a/modules/rebootneeded.sh
+++ b/modules/rebootneeded.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function rebootneeded {
   if [ -f "/etc/reboot-needed" ]; then

--- a/modules/reboots.sh
+++ b/modules/reboots.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function reboots {
   case "$1" in

--- a/modules/reboots.sh
+++ b/modules/reboots.sh
@@ -1,4 +1,3 @@
-
 function reboots {
   case "$1" in
     "")

--- a/modules/remote.sh
+++ b/modules/remote.sh
@@ -1,4 +1,3 @@
-
 function remote {
     option="$1"
 

--- a/modules/remote.sh
+++ b/modules/remote.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function remote {
     option="$1"

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -1,4 +1,3 @@
-
 function rename () { 
 
   if

--- a/modules/rename.sh
+++ b/modules/rename.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function rename () { 
 

--- a/modules/restore.sh
+++ b/modules/restore.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function restore {
   device="$1"

--- a/modules/restore.sh
+++ b/modules/restore.sh
@@ -1,4 +1,3 @@
-
 function restore {
   device="$1"
   if [ -z "$device" ]; then

--- a/modules/rtc.sh
+++ b/modules/rtc.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 declare -A rtcclockdata
 rtcclockdata["rasclock"]="dtoverlay=i2c-rtc,pcf2127"

--- a/modules/rtc.sh
+++ b/modules/rtc.sh
@@ -1,4 +1,3 @@
-
 declare -A rtcclockdata
 rtcclockdata["rasclock"]="dtoverlay=i2c-rtc,pcf2127"
 rtcclockdata["ds3231"]="dtoverlay=i2c-rtc,ds3231"

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function services {
   service_name="$1"

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -1,4 +1,3 @@
-
 function services {
   service_name="$1"
   command="$2"

--- a/modules/speedtest.sh
+++ b/modules/speedtest.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function speedtest {
   check_missing_packages "speedtest-cli"

--- a/modules/speedtest.sh
+++ b/modules/speedtest.sh
@@ -1,4 +1,3 @@
-
 function speedtest {
   check_missing_packages "speedtest-cli"
   /usr/bin/speedtest "$@"

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function ssh {
   status=$1

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -1,4 +1,3 @@
-
 function ssh {
   status=$1
   if [ "$status" = "on" ]; then

--- a/modules/sshkey.sh
+++ b/modules/sshkey.sh
@@ -1,4 +1,3 @@
-
 function sshkey () {
   if [ "$1" == "add" ]; then
     shift

--- a/modules/sshkey.sh
+++ b/modules/sshkey.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 
 function sshkey () {
   if [ "$1" == "add" ]; then

--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function sshtunnel {
   if { [ ! -f "/etc/tunnel" ] || [ ! -f "/etc/cron.d/autossh" ]; }  && [ "$1" != "add" ]; then

--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -1,4 +1,3 @@
-
 function sshtunnel {
   if { [ ! -f "/etc/tunnel" ] || [ ! -f "/etc/cron.d/autossh" ]; }  && [ "$1" != "add" ]; then
     echo "Error: no tunnel has been set up."

--- a/modules/staticwifi.sh
+++ b/modules/staticwifi.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function staticwifi {
   cp "$TEMPLATES/network/interfaces/modular" /etc/network/interfaces

--- a/modules/staticwifi.sh
+++ b/modules/staticwifi.sh
@@ -1,4 +1,3 @@
-
 function staticwifi {
   cp "$TEMPLATES/network/interfaces/modular" /etc/network/interfaces
   cp "$TEMPLATES/network/wlan0/static" /etc/network/interfaces.d/wlan0

--- a/modules/temperature.sh
+++ b/modules/temperature.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function temperature () {
   #Uses `vgencmd measure_temp` command to find CPU temperature of Raspberry Pi

--- a/modules/temperature.sh
+++ b/modules/temperature.sh
@@ -1,4 +1,3 @@
-
 function temperature () {
   #Uses `vgencmd measure_temp` command to find CPU temperature of Raspberry Pi
   reading=$(vcgencmd measure_temp)

--- a/modules/timezone.sh
+++ b/modules/timezone.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function timezone {
   timezone="$1"

--- a/modules/timezone.sh
+++ b/modules/timezone.sh
@@ -1,4 +1,3 @@
-
 function timezone {
   timezone="$1"
   if [ -z "$timezone" ];

--- a/modules/tor.sh
+++ b/modules/tor.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function tor {
   check_missing_packages "tor" "curl"

--- a/modules/tor.sh
+++ b/modules/tor.sh
@@ -1,4 +1,3 @@
-
 function tor {
   check_missing_packages "tor" "curl"
 

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function upgrade {
   tag=$1

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -1,4 +1,3 @@
-
 function upgrade {
   tag=$1
   if [ -z "$tag" ] && [ "$tag" != "--check" ];

--- a/modules/usb.sh
+++ b/modules/usb.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function usb {
   # check if hub-ctrl binary exists

--- a/modules/usb.sh
+++ b/modules/usb.sh
@@ -1,4 +1,3 @@
-
 function usb {
   # check if hub-ctrl binary exists
   if [ ! -e /usr/local/bin/hub-ctrl ]; then

--- a/modules/verbose.sh
+++ b/modules/verbose.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # $LOGFILE is used like so systemctl disable "$1" >"$LOGFILE" 2>"$LOGFILE"
 # /dev/null is the void (output and errors vanish) $(tty) is the terminal screen
 function verbose {

--- a/modules/version.sh
+++ b/modules/version.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function version {
   node -p "require('$SCRIPTFOLDER/package.json').version"

--- a/modules/version.sh
+++ b/modules/version.sh
@@ -1,4 +1,3 @@
-
 function version {
   node -p "require('$SCRIPTFOLDER/package.json').version"
 }

--- a/modules/vnc.sh
+++ b/modules/vnc.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function vnc {
   option=$1

--- a/modules/vnc.sh
+++ b/modules/vnc.sh
@@ -1,4 +1,3 @@
-
 function vnc {
   option=$1
   bootoptionstatus=$(systemctl is-enabled graphical.target)

--- a/modules/wifi.sh
+++ b/modules/wifi.sh
@@ -1,4 +1,3 @@
-
 function wifi {
 
   if [ -z "$1" ]; then

--- a/modules/wifi.sh
+++ b/modules/wifi.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function wifi {
 

--- a/modules/wificountry.sh
+++ b/modules/wificountry.sh
@@ -1,4 +1,3 @@
-
 function wificountry {
   country=$1
 

--- a/modules/wificountry.sh
+++ b/modules/wificountry.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function wificountry {
   country=$1

--- a/modules/wifihidden.sh
+++ b/modules/wifihidden.sh
@@ -1,4 +1,3 @@
-
 function wifihidden {
 
   if [ -z "$1" ]; then

--- a/modules/wifihidden.sh
+++ b/modules/wifihidden.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function wifihidden {
 

--- a/modules/wifistatus.sh
+++ b/modules/wifistatus.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 function wifistatus {
   # layman nomenclature for wifi signal strength

--- a/modules/wifistatus.sh
+++ b/modules/wifistatus.sh
@@ -1,4 +1,3 @@
-
 function wifistatus {
   # layman nomenclature for wifi signal strength
   #   perfect=(-10 ... -29)


### PR DESCRIPTION
Right now we have ```#!/bin/bash``` at the top of all our scripts inside the modules folder commonly called the 'shebang'. This is wrong for 3 reasons.
1. None of those files are executed directly by any code nor can they be because they contain functions.
2. Nor can they be executed because they are not set by chmod to be executable files.
3. The files in modules are sourced by cli.sh which automatically uses #!/bin/bash in cli.sh as the shell params as those files are executed by the source command. 

![](https://i.imgur.com/b9ZLFl.jpg)
