### PR TITLE
treehouses memory with global vars (fixes #686)

### DIFF
--- a/modules/memory.sh
+++ b/modules/memory.sh
@@ -1,5 +1,4 @@
 function memory_total() {
-  local option t_M t
   option=$1
   case $option in 
     '-g')
@@ -20,7 +19,6 @@ function memory_total() {
 }
 
 function memory_used {
-  local option u_M u bc_M bc ubc
   option=$1
   case $option in 
     '-g')
@@ -49,7 +47,6 @@ function memory_used {
 }
 
 function memory_free {
-  local option f_G f
   option=$1
   case $option in 
     '-g')
@@ -70,7 +67,6 @@ function memory_free {
 }
 
 function memory() {
-  local option
   if [ "$1" == "total" ] ; then
     memory_total $2
     echo "$t";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.13.16",
+  "version": "1.13.17",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
Fixes #686

Since the main `memory()` function calls the other functions, we can't use local variables since local variables will be out of scope.

Reverting back to global variables fixes the issues.