### PR TITLE
treehouses detectrpi model (fixes #643)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ password <password>                       changes the password for 'pi' user
 sshkey <add|list|delete|deleteall|github> used for adding or removing ssh keys for authentication
 version                                   returns the version of cli.sh command
 image                                     returns version of the system image installed
-detectrpi                                 detects the hardware version of a raspberry pi
+detectrpi [model]                         detects the hardware version of a raspberry pi
 detect                                    detects the hardware version of any device
 ethernet <ip> <mask> <gateway> <dns>      configures rpi network interface to a static ip address
 discover <scan|interface|ping|ports|mac>  performs network scan and discovers all raspberry pis on the network

--- a/_treehouses
+++ b/_treehouses
@@ -22,6 +22,7 @@ _treehouses_complete()
   container_cmds="none docker balena"
   coralenv_cmds="install demo-on demo-off demo-always-on"
   discover_cmds="rpi scan interface ping ports mac"
+  detectrpi_cmds="model"
   help_cmds=$commands
   led_cmds="green red dance thanksgiving christmas newyear lunarnewyear valentine carneval"
   log_cmds="0 1 2 3 4 show max"
@@ -92,6 +93,9 @@ _treehouses_complete()
       "discover")
         COMPREPLY=( $(compgen -W "$discover_cmds" -- $cur) )
         ;;
+      "detectrpi")
+        COMPREPLY=( $(compgen -W "$detectrpi_cmds" -- $cur) )
+        ;;      
       "help")
         COMPREPLY=( $(compgen -W "$help_cmds" -- $cur) )
         ;;

--- a/cli.sh
+++ b/cli.sh
@@ -94,7 +94,7 @@ case $1 in
     detect
     ;;
   detectrpi)
-    detectrpi
+    detectrpi "$2"
     ;;
   wifi)
     checkrpi

--- a/cli.sh
+++ b/cli.sh
@@ -94,7 +94,7 @@ case $1 in
     detect
     ;;
   detectrpi)
-    detectrpi "$2"
+    detectrpi "$2" "$3"
     ;;
   wifi)
     checkrpi

--- a/modules/detectrpi.sh
+++ b/modules/detectrpi.sh
@@ -57,7 +57,7 @@ function detectrpi {
     if [[ "$1" == "" ]];
     then
       echo ${rpimodels[$rpimodel]}
-    elif [[ "$1" == "model" ]]; 
+    elif [[ "$1" == "model" ]] && [[ "$2" == "" ]]; 
     then
       echo "$rpimodel"
     else

--- a/modules/detectrpi.sh
+++ b/modules/detectrpi.sh
@@ -61,7 +61,7 @@ function detectrpi {
     then
       echo "$rpimodel"
     else
-      logit "unknown command"
+      log_and_exit1 "Error: only 'detectrpi', and 'detectrpi model' commands supported"
     fi
   else
     echo "nonrpi"

--- a/modules/detectrpi.sh
+++ b/modules/detectrpi.sh
@@ -54,7 +54,15 @@ function detectrpi {
 
   if [ "$found" == 1 ];
   then
-    echo ${rpimodels[$rpimodel]}
+    if [[ "$1" == "" ]];
+    then
+      echo ${rpimodels[$rpimodel]}
+    elif [[ "$1" == "model" ]]; 
+    then
+      echo "$rpimodel"
+    else
+      logit "unknown command"
+    fi
   else
     echo "nonrpi"
   fi
@@ -69,6 +77,9 @@ function detectrpi_help {
   echo
   echo "Example:"
   echo "  $BASENAME detectrpi"
-  echo "      Prints the model number"
+  echo "      Prints the Raspberry Pi name"
+  echo
+  echo "  $BASENAME detectrpi model"
+  echo "      Prints the model number of the RPi"
   echo
 }

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -9,7 +9,7 @@ function help_default {
   echo "   sshkey <add|list|delete|deleteall|github> used for adding or removing ssh keys for authentication"        
   echo "   version                                   returns the version of $BASENAME command"
   echo "   image                                     returns version of the system image installed"
-  echo "   detectrpi                                 detects the hardware version of a raspberry pi"
+  echo "   detectrpi [model]                         detects the hardware version of a raspberry pi"
   echo "   detect                                    detects the hardware version of any device"
   echo "   ethernet <ip> <mask> <gateway> <dns>      configures rpi network interface to a static ip address"
   echo "   discover <scan|interface|ping|ports|mac>  performs network scan and discovers all raspberry pis on the network"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.13.19",
+  "version": "1.13.20",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
- Allows for us to query the model number directly
- Instead of "RPi4B+" we can get "c03112"
![](https://i.imgur.com/wvBiNvN.png)