### PR TITLE
treehouses tmux (fixes #698)

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -69,7 +69,7 @@ if [[ $(pstree -ps $$) == *"ssh"* ]] && [[ "$RUNSCREEN" -eq 0 ]]; then
   checkroot
   RUNSCREEN=1
   conf_var_update "RUNSCREEN" "$RUNSCREEN"
-  tmux new-session -d "$0 $@"
+  tmux new-session -d "$0 $*"
   RUNSCREEN=0
   conf_var_update "RUNSCREEN" "$RUNSCREEN"
 fi

--- a/cli.sh
+++ b/cli.sh
@@ -64,6 +64,15 @@ source "$SCRIPTFOLDER/modules/usb.sh"
 source "$SCRIPTFOLDER/modules/remote.sh"
 source "$SCRIPTFOLDER/modules/blocker.sh"
 
+# Runs command in new tmux screen to avoid commands not getting run with ssh closes
+if [[ $(pstree -ps $$) == *"ssh"* ]] && [[ "$USINGSSH" -eq 0 ]]; then
+  USINGSSH=1
+  conf_var_update "USINGSSH" "$USINGSSH"
+  tmux new-session -d "$0 $@"
+  USINGSSH=0
+  conf_var_update "USINGSSH" "$USINGSSH"
+fi
+
 case $1 in
   expandfs)
     checkrpi

--- a/cli.sh
+++ b/cli.sh
@@ -65,12 +65,13 @@ source "$SCRIPTFOLDER/modules/remote.sh"
 source "$SCRIPTFOLDER/modules/blocker.sh"
 
 # Runs command in new tmux screen to avoid commands not getting run with ssh closes
-if [[ $(pstree -ps $$) == *"ssh"* ]] && [[ "$USINGSSH" -eq 0 ]]; then
-  USINGSSH=1
-  conf_var_update "USINGSSH" "$USINGSSH"
-  tmux new-session -d "$0 $*"
-  USINGSSH=0
-  conf_var_update "USINGSSH" "$USINGSSH"
+if [[ $(pstree -ps $$) == *"ssh"* ]] && [[ "$RUNSCREEN" -eq 0 ]]; then
+  checkroot
+  RUNSCREEN=1
+  conf_var_update "RUNSCREEN" "$RUNSCREEN"
+  tmux new-session -d "$0 $@"
+  RUNSCREEN=0
+  conf_var_update "RUNSCREEN" "$RUNSCREEN"
 fi
 
 case $1 in

--- a/cli.sh
+++ b/cli.sh
@@ -68,7 +68,7 @@ source "$SCRIPTFOLDER/modules/blocker.sh"
 if [[ $(pstree -ps $$) == *"ssh"* ]] && [[ "$USINGSSH" -eq 0 ]]; then
   USINGSSH=1
   conf_var_update "USINGSSH" "$USINGSSH"
-  tmux new-session -d "$0 $@"
+  tmux new-session -d "$0 $*"
   USINGSSH=0
   conf_var_update "USINGSSH" "$USINGSSH"
 fi

--- a/modules/config.sh
+++ b/modules/config.sh
@@ -10,6 +10,7 @@ NC='\033[0m'
 LOGFILE=/dev/null
 LOG=0
 BLOCKER=0
+USINGSSH=0
 
 if [[ -f "$CONFIGFILE" ]]; then
   source "$CONFIGFILE"

--- a/modules/config.sh
+++ b/modules/config.sh
@@ -10,7 +10,7 @@ NC='\033[0m'
 LOGFILE=/dev/null
 LOG=0
 BLOCKER=0
-USINGSSH=0
+RUNSCREEN=0
 
 if [[ -f "$CONFIGFILE" ]]; then
   source "$CONFIGFILE"


### PR DESCRIPTION
Fixes #698 
When connecting over ssh. Should detect automatically. And run the command in a detached tmux screen.
To test:
```
ssh pi@your.ip.address
sudo apt install tmux; git clone http://github.com/treehouses/cli; cd cli; git checkout add-sshcheck;
./cli.sh image
./cli.sh tor add 8080 # should run all the way thru even after disconnect from ssh
```