### PR TITLE
treehouses networkmode info checkroot (fixes #709)

### DIFF
--- a/modules/networkmode.sh
+++ b/modules/networkmode.sh
@@ -33,11 +33,10 @@ function networkmode {
   esac
 
   if [ "$1" == "info" ]; then
+    checkroot
     if [ "$network_mode" == "wifi" ]; then
-      checkroot
       get_wpa_supplicant_settings
     elif [ "$network_mode" == "bridge" ]; then
-      checkroot
       echo "wlan0: $(get_wpa_supplicant_settings)"
       echo "ap0: $(get_hostapd_settings)"
     elif [ "$network_mode" == "ap local" ] || [ "$network_mode" == "ap internet" ]; then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.13.24",
+  "version": "1.13.25",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
Fixes issue #709 treehouses networkmode info should only work when root 