### PR TITLE
treehouses remote minimum version check (fixes #728)

### DIFF
--- a/_treehouses
+++ b/_treehouses
@@ -42,7 +42,7 @@ _treehouses_complete()
   tor_cmds="list add delete deleteall start stop destroy notice status refresh"
   usb_cmds="on off"
   notice_cmds="on off add delete list"
-  remote_cmds="status upgrade services"
+  remote_cmds="status upgrade services version"
 
 # upgrade_cmds="" I am not sure whether we should put autocompletion here.
 

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -64,7 +64,7 @@ function help_default {
   echo "   cron [list|add|delete|deleteall]          adds, deletes a custom cron job or deletes, lists all cron jobs"
   echo "        [0W|tor|timestamp]                   adds premade cron job (or removes it if already active)"
   echo "   usb [on|off]                              turns usb ports on or off"
-  echo "   remote [status|upgrade|services]          helps with treehouses remote android app"
+  echo "   remote [status|upgrade|services|version]  helps with treehouses remote android app"
   echo "   log <0|1|2|3|4|show|max>                  gets/sets log level and shows log"
   echo "   blocker <0|1|2|3|4||max>                  website blocking levels using /etc/hosts"
   echo

--- a/modules/remote.sh
+++ b/modules/remote.sh
@@ -1,62 +1,68 @@
 function remote {
-    local option results
-    option="$1"
+  local option results
+  option="$1"
 
-    if [ "$option" = "status" ]; then
-        results=""
-        results+="$(internet) "
-        results+="$(bluetooth mac) "
-        results+="$(image) "
-        results+="$(version) "
-        results+="$(detectrpi)"
+  if [ "$option" = "status" ]; then
+    results=""
+    results+="$(internet) "
+    results+="$(bluetooth mac) "
+    results+="$(image) "
+    results+="$(version) "
+    results+="$(detectrpi)"
 
-        echo ${results}
-    elif [ "$option" = "upgrade" ]; then
-        upgrade --check
-    elif [ "$option" = "services" ]; then
-        if [ "$2" = "available" ]; then
-            results="Available: "
-            results+="$(services available)"
+    echo ${results}
+  elif [ "$option" = "upgrade" ]; then
+    upgrade --check
+  elif [ "$option" = "services" ]; then
+    if [ "$2" = "available" ]; then
+      results="Available: "
+      results+="$(services available)"
 
-            echo ${results}
-        elif [ "$2" = "installed" ]; then
-            results="Installed: "
-            results+="$(services installed)"
+      echo ${results}
+    elif [ "$2" = "installed" ]; then
+      results="Installed: "
+      results+="$(services installed)"
 
-            echo ${results}
-        elif [ "$2" = "running" ]; then
-            results="Running: "
-            results+="$(services running)"
+      echo ${results}
+    elif [ "$2" = "running" ]; then
+      results="Running: "
+      results+="$(services running)"
 
-            echo ${results}
-        fi
-    else
-        echo "unknown command option"
-        echo "usage: $BASENAME remote [status | upgrade]"
+      echo ${results}
     fi
+  elif [ "$option" = "version" ]; then
+    if (( $2 > node -p "require('$SCRIPTFOLDER/package.json').remote-min-version" )); then
+      true
+    else
+      false
+    fi
+  else
+    echo "unknown command option"
+    echo "usage: $BASENAME remote [status | upgrade]"
+  fi
 }
 
 function remote_help {
-    echo
-    echo "Usage: $BASENAME remote [status | upgrade | services]"
-    echo
-    echo "Returns a string representation of the current status of the Raspberry Pi"
-    echo "Used for Treehouses Remote"
-    echo
-    echo "$BASENAME remote status"
-    echo "<internet> <bluetooth mac> <image> <version> <detectrpi>"
-    echo "     │            │           │        │          │"
-    echo "     │            │           │        │          └── model number of rpi"
-    echo "     │            │           │        └───────────── current cli version"
-    echo "     │            │           └────────────────────── current treehouses image version"
-    echo "     │            └────────────────────────────────── bluetooth mac address"
-    echo "     └─────────────────────────────────────────────── internet connection status"
-    echo
-    echo "$BASENAME remote upgrade"
-    echo "true if an upgrade is available"
-    echo "false otherwise"
-    echo
-    echo "$BASENAME remote services [available | installed | running]"
-    echo "Available: | Installed: | Running: <list of services>"
-    echo
+  echo
+  echo "Usage: $BASENAME remote [status | upgrade | services]"
+  echo
+  echo "Returns a string representation of the current status of the Raspberry Pi"
+  echo "Used for Treehouses Remote"
+  echo
+  echo "$BASENAME remote status"
+  echo "<internet> <bluetooth mac> <image> <version> <detectrpi>"
+  echo "     │            │           │        │          │"
+  echo "     │            │           │        │          └── model number of rpi"
+  echo "     │            │           │        └───────────── current cli version"
+  echo "     │            │           └────────────────────── current treehouses image version"
+  echo "     │            └────────────────────────────────── bluetooth mac address"
+  echo "     └─────────────────────────────────────────────── internet connection status"
+  echo
+  echo "$BASENAME remote upgrade"
+  echo "true if an upgrade is available"
+  echo "false otherwise"
+  echo
+  echo "$BASENAME remote services [available | installed | running]"
+  echo "Available: | Installed: | Running: <list of services>"
+  echo
 }

--- a/modules/remote.sh
+++ b/modules/remote.sh
@@ -33,6 +33,7 @@ function remote {
   elif [ "$option" = "version" ]; then
     if [ -z "$2" ]; then
       echo "version number required"
+      echo "usage: $BASENAME remote version <version_number>"
       exit 1
     fi
     if [ "$2" -ge "$(node -p "require('$SCRIPTFOLDER/package.json').remote_min_version")" ]; then

--- a/modules/remote.sh
+++ b/modules/remote.sh
@@ -36,7 +36,7 @@ function remote {
       echo "usage: $BASENAME remote version <version_number>"
       exit 1
     fi
-    if [ "$2" -ge "$(node -p "require('$SCRIPTFOLDER/package.json').remote_min_version")" ]; then
+    if [ "$2" -ge "$(node -p "require('$SCRIPTFOLDER/package.json').remote")" ]; then
       echo true
     else
       echo false

--- a/modules/remote.sh
+++ b/modules/remote.sh
@@ -43,7 +43,7 @@ function remote {
     fi
   else
     echo "unknown command option"
-    echo "usage: $BASENAME remote [status | upgrade]"
+    echo "usage: $BASENAME remote [status | upgrade | services | version]"
   fi
 }
 

--- a/modules/remote.sh
+++ b/modules/remote.sh
@@ -49,7 +49,7 @@ function remote {
 
 function remote_help {
   echo
-  echo "Usage: $BASENAME remote [status | upgrade | services]"
+  echo "Usage: $BASENAME remote [status | upgrade | services | version]"
   echo
   echo "Returns a string representation of the current status of the Raspberry Pi"
   echo "Used for Treehouses Remote"
@@ -69,5 +69,9 @@ function remote_help {
   echo
   echo "$BASENAME remote services [available | installed | running]"
   echo "Available: | Installed: | Running: <list of services>"
+  echo
+  echo "$BASENAME remote version <version_number>"
+  echo "true if <version_number> >= \"remote_min_version\" in package.json"
+  echo "false otherwise"
   echo
 }

--- a/modules/remote.sh
+++ b/modules/remote.sh
@@ -31,10 +31,14 @@ function remote {
       echo ${results}
     fi
   elif [ "$option" = "version" ]; then
-    if (( $2 > node -p "require('$SCRIPTFOLDER/package.json').remote-min-version" )); then
-      true
+    if [ -z "$2" ]; then
+      echo "version number required"
+      exit 1
+    fi
+    if [ "$2" -ge "$(node -p "require('$SCRIPTFOLDER/package.json').remote_min_version")" ]; then
+      echo true
     else
-      false
+      echo false
     fi
   else
     echo "unknown command option"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@treehouses/cli",
   "version": "1.13.26",
-  "remote-min-version": "",
+  "remote_min_version": "",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@treehouses/cli",
   "version": "1.13.26",
-  "remote_min_version": "",
+  "remote_min_version": "2069",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@treehouses/cli",
   "version": "1.13.26",
+  "remote-min-version": "",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@treehouses/cli",
   "version": "1.13.26",
-  "remote_min_version": "2069",
+  "remote": "2069",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
Fixes #728

`./cli.sh remote version <version_number>` where `<version_number>` is the version of remote you want to check.