### PR TITLE
treehouses exit fixes (fixes #724)

### DIFF
--- a/modules/ap.sh
+++ b/modules/ap.sh
@@ -42,7 +42,7 @@ function ap {
     echo "ap local" > /etc/network/mode
   else
     echo "Error: only 'local' and 'internet' modes are supported".
-    exit 0
+    exit 1
   fi
 
   cp "$TEMPLATES/network/10-wpa_supplicant" /lib/dhcpcd/dhcpcd-hooks/10-wpa_supplicant

--- a/modules/apchannel.sh
+++ b/modules/apchannel.sh
@@ -10,7 +10,7 @@ function apchannel {
 
   if [ -z "$new_channel" ]; then
       echo $current_channel;
-      exit 0
+      return
   fi
 
   checkroot

--- a/modules/aphidden.sh
+++ b/modules/aphidden.sh
@@ -42,7 +42,7 @@ function aphidden {
     echo "hidden ap local" > /etc/network/mode
   else
     echo "Error: only 'local' and 'internet' modes are supported".
-    exit 0
+    exit 1
   fi
 
   cp "$TEMPLATES/network/10-wpa_supplicant" /lib/dhcpcd/dhcpcd-hooks/10-wpa_supplicant

--- a/modules/blocker.sh
+++ b/modules/blocker.sh
@@ -37,29 +37,29 @@ function apply_blocker {
 function blocker {
   case "$1" in
     "")
-	  case "$BLOCKER" in
-	    "0")
-		  logit "blocker 0: blocker is disabled"
-		  ;;
-	    "1")
-		  logit "blocker 1: level is set to ads (adware + malware)"
-		  ;;
-	    "2")
-		  logit "blocker 2: level is set to ads + porn"
-		  ;;
-	    "3")
-		  logit "blocker 3: level is set to ads + gambling + porn"
-		  ;;
-	    "4")
-		  logit "blocker 4: level is set to ads + fakenews + gambling + porn"
-		  ;;
-		"max")
-		  logit "blocker X: level is set to ads + fakenews + gambling + porn + social"
-		  ;;
-	  esac
-      exit 0;
+	    case "$BLOCKER" in
+	      "0")
+		      logit "blocker 0: blocker is disabled"
+		      ;;
+	      "1")
+		      logit "blocker 1: level is set to ads (adware + malware)"
+		      ;;
+	      "2")
+		      logit "blocker 2: level is set to ads + porn"
+		      ;;
+	      "3")
+		      logit "blocker 3: level is set to ads + gambling + porn"
+		      ;;
+	      "4")
+		      logit "blocker 4: level is set to ads + fakenews + gambling + porn"
+		      ;;
+		    "max")
+		      logit "blocker X: level is set to ads + fakenews + gambling + porn + social"
+		      ;;
+	    esac
+      return
       ;;
-	"0")
+	  "0")
       BLOCKER=0
       apply_blocker "blocker 0: blocker disabled"
       ;;
@@ -79,10 +79,10 @@ function blocker {
       BLOCKER=4
       apply_blocker "blocker 4: level set to ads + fakenews + gambling + porn"
       ;;
-	"max")
-	  BLOCKER=max
+	  "max")
+	    BLOCKER=max
       apply_blocker "blocker X: level set to ads + fakenews + gambling + porn + social"
-	  ;;
+	    ;;
     *)
       log_and_exit1 "Error: only '0' '1' '2' '3' '4' 'max' options are supported"
       ;;

--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -31,7 +31,7 @@ function bluetooth {
     btidfile=/etc/bluetooth-id
     if [ ! -f "${btidfile}" ]; then
       echo "No ID. Bluetooth service is not on."
-      exit 0
+      exit 1
     fi
 
     bid=$(cat ${btidfile})

--- a/modules/bluetoothid.sh
+++ b/modules/bluetoothid.sh
@@ -4,7 +4,7 @@ function bluetoothid () {
   btidfile=/etc/bluetooth-id
   if [ ! -f "${btidfile}" ]; then
     echo "No ID. Bluetooth service is not on."
-    exit 0
+    exit 1
   fi
 
   bid=$(cat ${btidfile})  #get id of the bluetooth

--- a/modules/camera.sh
+++ b/modules/camera.sh
@@ -53,7 +53,6 @@ function camera {
 
     "*")
       camera_help
-      exit 0
     ;;
   esac
 }

--- a/modules/container.sh
+++ b/modules/container.sh
@@ -1,32 +1,32 @@
 function container {
 if [ "$1" == "docker" ] ; then
     container_docker;
-    exit 0
+    return
   fi
 
   if [ "$1" == "balena" ] ; then
     container_balena;
-    exit 0
+    return
   fi
 
   if [ "$1" == "none" ] ; then
     container_none;
-    exit 0
+    return
   fi
   
   if [ "$(systemctl is-enabled docker)" == "enabled" ] ; then
     echo "docker";
-    exit 0
+    return
   fi
   
   if [ "$(systemctl is-enabled balena)" == "enabled" ] ; then
     echo "balena";
-    exit 0
+    return
   fi
   
   if [ "$(systemctl is-enabled docker)" == "disabled" ] && [ "$(systemctl is-enabled balena)" == "disabled" ] ; then
     echo "none";
-    exit 0
+    return
   fi
 }
 

--- a/modules/default.sh
+++ b/modules/default.sh
@@ -2,20 +2,20 @@ function default {
   if [ "$1" == "notice" ] ; then
     default_notice
     echo 'Success: the message has been reset to default';
-    exit 0
+    return
   fi
 
   if [ "$1" == "tunnel" ] ; then
     default_tunnel
     echo 'Success: the tunnel mode has been reset to default, please reboot your device';
-    exit 0
+    return
   fi
 
   if [ "$1" == "network" ] ; then
     checkrpi
     default_network
     echo 'Success: the network mode has been reset to default, please reboot your device';
-    exit 0
+    return
   fi
 
   rename "raspberrypi" > "$LOGFILE" 2>"$LOGFILE"

--- a/modules/internet.sh
+++ b/modules/internet.sh
@@ -1,7 +1,7 @@
 function internet {
   if wget -q --spider -T 3 --no-check-certificate https://www.google.com; then
     echo "true"
-    exit 0
+    return
   fi
   echo "false"
 }

--- a/modules/led.sh
+++ b/modules/led.sh
@@ -88,7 +88,7 @@ function led {
         echo -e "$red: $currentRed"
       fi
 
-      exit 0
+      return
     else
       echo -e "${RED}Error:${NC} led '$color' is not present"
       exit 1

--- a/modules/log.sh
+++ b/modules/log.sh
@@ -12,27 +12,27 @@ function logit() {
         ;;
 	  # Stuff might break
       "WARNING")
-	    if [[ "$LOG" -gt "1" ]]; then
+	      if [[ "$LOG" -gt "1" ]]; then
           logger -p local0.warning -t @treehouses/cli "WARNING: $1"
-		fi 
+		    fi 
         ;;
 	  # Stuff did break
       "ERROR")
-	  	if [[ "$LOG" -gt "2" ]]; then
+	  	  if [[ "$LOG" -gt "2" ]]; then
           logger -p local0.err -t @treehouses/cli "ERROR: $1"
-		fi
+		    fi
         ;;
 	  # Developer wants to log as well
       "DEBUG")
-	  	if [[ "$LOG" -gt "3" ]]; then
+	  	  if [[ "$LOG" -gt "3" ]]; then
           logger -p local0.debug -t @treehouses/cli "DEBUG: $1"
-		fi
+		    fi
         ;;
     esac
-	sync;
+	  sync;
   fi
   if [[ "$2" == "1" ]]; then
-    return 0;
+    return
   fi
   echo "$1"
 }
@@ -49,29 +49,29 @@ function log {
   lines="$2"
   case "$1" in
     "")
-	  case "$LOG" in
-	    "0")
-		  logit "log 0: log is disabled"
-		  ;;
-	    "1")
-		  logit "log 1: level is set to Info"
-		  ;;
-	    "2")
-		  logit "log 2: level is set to Info and Warning"
-		  ;;
-	    "3")
-		  logit "log 3: level is set to Info, Warning, and Error"
-		  ;;
-	    "4")
-		  logit "log 4: level is set to Info, Warning, Error, and Debug"
-		  ;;
-		"max")
-		  logit "log X: level is set to max"
-		  ;;
-	  esac
-      exit 0;
+	    case "$LOG" in
+	      "0")
+		      logit "log 0: log is disabled"
+		      ;;
+	      "1")
+		      logit "log 1: level is set to Info"
+		      ;;
+	      "2")
+		      logit "log 2: level is set to Info and Warning"
+		      ;;
+	      "3")
+		      logit "log 3: level is set to Info, Warning, and Error"
+		      ;;
+	      "4")
+		      logit "log 4: level is set to Info, Warning, Error, and Debug"
+		      ;;
+		    "max")
+		      logit "log X: level is set to max"
+		      ;;
+	    esac
+      return
       ;;
-	"0")
+	  "0")
       LOG=0
       logit "log 0: log disabled"
       ;;
@@ -91,18 +91,18 @@ function log {
       LOG=4
       logit "log 4: level set to Info, Warning, Error, and Debug" "" "DEBUG"
       ;;
-	"show")
-	  if [ -z "$2" ]; then
-	    lines="6"
-	  elif ! [[ "$2" =~ ^[0-9]+$ ]]; then
-	    log_and_exit1 "Error: only numbers allowed"
+	  "show")
+	    if [ -z "$2" ]; then
+	      lines="6"
+	    elif ! [[ "$2" =~ ^[0-9]+$ ]]; then
+	      log_and_exit1 "Error: only numbers allowed"
       fi
-	  grep "@treehouses/cli" /var/log/syslog | tail -n "$lines"
-	  ;;
-	"max")
-	  LOG=max
-	  logit "log X: level set to max" "" "DEBUG"
-	  ;;
+	    grep "@treehouses/cli" /var/log/syslog | tail -n "$lines"
+	    ;;
+	  "max")
+	    LOG=max
+	    logit "log X: level set to max" "" "DEBUG"
+	    ;;
     *)
       log_and_exit1 "Error: only '0' '1' '2' '3' '4' 'show' 'max' options are supported"
       ;;

--- a/modules/memory.sh
+++ b/modules/memory.sh
@@ -72,19 +72,19 @@ function memory() {
   if [ "$1" == "total" ] ; then
     memory_total $2
     echo "$t";
-    exit 0
+    return
   fi
 
   if [ "$1" == "used" ] ; then
     memory_used $2
     echo "$ubc";
-    exit 0
+    return
   fi
 
   if [ "$1" == "free" ] ; then
     memory_free $2
     echo "$f";
-    exit 0
+    return
   fi
 
   option=$1

--- a/modules/ntp.sh
+++ b/modules/ntp.sh
@@ -27,7 +27,7 @@ function ntp {
     echo "Success: please reboot you rpi to apply changes."
   else
     echo "Error: only on, off options are supported"
-    exit 0
+    exit 1
   fi
 }
 

--- a/modules/rebootneeded.sh
+++ b/modules/rebootneeded.sh
@@ -1,7 +1,7 @@
 function rebootneeded {
   if [ -f "/etc/reboot-needed" ]; then
     echo "true";
-    exit 0
+    return
   fi
 
   echo "false"

--- a/modules/rtc.sh
+++ b/modules/rtc.sh
@@ -35,10 +35,10 @@ function rtc {
   if [ "$status" = "on" ]; then
     if [ -z "$clock" ]; then
       echo "Error: you need to specify a clock"
-      exit 0
+      exit 1
     elif [ -z "${rtcclockdata[$clock]}" ]; then
       echo "Error: the clock is not supported."
-      exit 0
+      exit 1
     else
       write_rtc "${rtcclockdata[$clock]}"
 
@@ -73,7 +73,7 @@ function rtc {
     echo "Success: clock changed. Please reboot"
   else
     echo "Error: only on, off options are supported"
-    exit 0
+    exit 1
   fi
 }
 

--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -4,7 +4,7 @@ function sshtunnel {
   if { [ ! -f "/etc/tunnel" ] || [ ! -f "/etc/cron.d/autossh" ]; }  && [ "$1" != "add" ]; then
     echo "Error: no tunnel has been set up."
     echo "Run '$BASENAME sshtunnel add' to add a key for the tunnel."
-    exit 0
+    exit 1
   fi      
   portinterval="$2"
   host="$3"

--- a/modules/tor.sh
+++ b/modules/tor.sh
@@ -15,7 +15,7 @@ function tor {
 
   if [ -z "$1" ]; then
     cat "/var/lib/tor/treehouses/hostname"
-    exit 0
+    return
   fi
 
   if [ "$1" = "list" ]; then
@@ -70,7 +70,7 @@ function tor {
 
     if ! grep -wq "HiddenServicePort $2" /etc/tor/torrc ; then
       echo "Port $2 is not assigned"
-      exit 0
+      exit 1
     fi
 
     sed -i "/^HiddenServicePort $2 /d" /etc/tor/torrc

--- a/modules/verbose.sh
+++ b/modules/verbose.sh
@@ -9,7 +9,7 @@ function verbose {
       else
         logit "Verbosity is on"
       fi
-      exit 0;
+      return
       ;;
     "on")
       LOGFILE=$(tty)

--- a/modules/wifistatus.sh
+++ b/modules/wifistatus.sh
@@ -17,7 +17,7 @@ function wifistatus {
       #check if device has wifi
       if iwconfig wlan0 2>&1 | grep -q "No such device"; then
         echo "Error: no wifi device is present"
-        exit 0
+        exit 1
       fi
       #check if device is connected to wifi
       if iwconfig wlan0 | grep -q "ESSID:off/any"; then


### PR DESCRIPTION
- This changes ```exit 0``` where possible to ```return``` which will return to ```cli.sh``` which will run to the end and exit 0 itself. 
- Changes ```exit 0``` to ```exit 1``` where it was needed. 
- Kind of similar to the code already there but less confusing because of the removal of ```exit 0``` mixing with ```exit 1```. Now we know ```return``` means success and anything with ```exit``` in it probably means failure. 