### PR TITLE
treehouses bluetoothid remove cat

### DIFF
--- a/modules/bluetoothid.sh
+++ b/modules/bluetoothid.sh
@@ -1,4 +1,4 @@
-function bluetoothid () {
+function bluetoothid() {
   local btidfile bid nname
   #check if bluetooth has an id
   btidfile=/etc/bluetooth-id
@@ -7,7 +7,7 @@ function bluetoothid () {
     exit 0
   fi
 
-  bid=$(cat ${btidfile})  #get id of the bluetooth
+  bid=$(<${btidfile})  #get id of the bluetooth
   nname=$(uname -n)  #get network name
 
   case "$1" in
@@ -24,7 +24,7 @@ function bluetoothid () {
   esac
 }
 
-function bluetoothid_help () {
+function bluetoothid_help() {
   echo
   echo "Usage: $BASENAME bluetoothid [number]"
   echo


### PR DESCRIPTION
- Useless use of cat: https://en.wikipedia.org/wiki/Cat_(Unix)#Useless_use_of_cat
Tested on RPi4:
```
pi@raspberrypi:~/Documents/cli $ ./cli.sh bluetoothid
raspberrypi-0945
pi@raspberrypi:~/Documents/cli $ ./cli.sh bluetoothid number
0945
pi@raspberrypi:~/Documents/cli $ ./cli.sh bluetoothid sfsdfsd
Argument not valid; leave blank or use "number"
```