### PR TITLE
treehouses bluetooth remove cat

### DIFF
--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -24,7 +24,7 @@ function bluetooth {
 
   elif [ "$status" = "mac" ]; then
     macfile=/sys/kernel/debug/bluetooth/hci0/identity
-    macadd=$(cat ${macfile})
+    macadd=$(<${macfile})
     echo "${macadd:0:17}"
 
   elif [ "$status" = "id" ]; then
@@ -34,7 +34,7 @@ function bluetooth {
       exit 0
     fi
 
-    bid=$(cat ${btidfile})
+    bid=$(<${btidfile})
     nname=$(uname -n)
 
     case "$2" in


### PR DESCRIPTION
- Useless use of cat: https://en.wikipedia.org/wiki/Cat_(Unix)#Useless_use_of_cat

Tested on RPi4:
```
pi@raspberrypi:~/Documents/cli $ sudo ./cli.sh bluetooth id
raspberrypi-0945
pi@raspberrypi:~/Documents/cli $ sudo ./cli.sh bluetooth dsfsdf
Error: only 'on', 'off', 'pause' options are supported
pi@raspberrypi:~/Documents/cli $ sudo ./cli.sh bluetooth on
Success: the bluetooth service has been started.
pi@raspberrypi:~/Documents/cli $ sudo ./cli.sh bluetooth off
Success: the bluetooth service has been switched to default, and the service has been stopped.
pi@raspberrypi:~/Documents/cli $ sudo ./cli.sh bluetooth pause
Success: the bluetooth service has been switched to default, and the service has been stopped.
```