### PR TITLE
treehouses networkmode remove cat

### DIFF
--- a/modules/networkmode.sh
+++ b/modules/networkmode.sh
@@ -2,7 +2,7 @@ function networkmode {
   local network_mode interfaces ifaces
   network_mode="default"
   if [ -f "/etc/network/mode" ]; then
-    network_mode=$(cat "/etc/network/mode")
+    network_mode=$(</etc/network/mode)
   fi
 
   interfaces=()


### PR DESCRIPTION
- Useless use of cat: https://en.wikipedia.org/wiki/Cat_(Unix)#Useless_use_of_cat
- https://stackoverflow.com/questions/7427262/how-to-read-a-file-into-a-variable-in-shell

Tested on RPi4
```
pi@raspberrypi:~/Documents/cli $ ./cli.sh networkmode
wifi
```