### PR TITLE
treehouses usb remove cat

### DIFF
--- a/modules/usb.sh
+++ b/modules/usb.sh
@@ -34,7 +34,7 @@ function usb {
       echo "usb ports turned on"
     elif [ "$command" = "off" ]; then
       # check for connected ethernet
-      if [ "$(cat /sys/class/net/eth0/carrier)" = "1" ]; then
+      if [ "$(</sys/class/net/eth0/carrier)" = "1" ]; then
         read -r -p "The ethernet port on your Raspberry Pi 4 is connected. Turning off usb power will interfere with your ethernet connection. Do you wish to continue? Y or N" yn
         case $yn in
           [Yy]*)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.13.31",
+  "version": "1.13.37",
   "remote": "2069",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
- Useless use of cat: https://en.wikipedia.org/wiki/Cat_(Unix)#Useless_use_of_cat
- https://stackoverflow.com/questions/7427262/how-to-read-a-file-into-a-variable-in-shell

Tested on RPi4 Successfully:
```
# NOTE MUST HAVE ETHERNET CORD PLUGGED INTO PI TO TEST THIS
pi@raspberrypi:~/Documents/cli $ sudo ./cli.sh usb off
The ethernet port on your Raspberry Pi 4 is connected. Turning off usb power will interfere with your ethernet connection. Do you wish to continue? Y or NN
```