### PR TITLE
treehouses services url (fixes #833)

### DIFF
--- a/modules/services.sh
+++ b/modules/services.sh
@@ -267,7 +267,7 @@ function services {
               fi
               echo $tor_url
             done
-          elif [ "$command_option" = "both" ]; then
+          elif [ "$command_option" = "" ]; then
             services $service_name url local
             services $service_name url tor
           else

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -267,7 +267,8 @@ function services {
               fi
               echo $tor_url
             done
-          elif [ "$command_option" = "" ]; then
+          #DEPRECATED#### TO DO: Remove both
+          elif [ "$command_option" = "both" ] || [ "$command_option" = "" ]; then
             services $service_name url local
             services $service_name url tor
           else
@@ -434,7 +435,7 @@ function services_help {
   echo "                             ..... autorun [true|false]"
   echo "                             ..... ps"
   echo "                             ..... info"
-  echo "                             ..... url <local|tor|both>"
+  echo "                             ..... url <local|tor>"
   echo "                             ..... port"
   echo "                             ..... size"
   echo
@@ -460,10 +461,9 @@ function services_help {
   echo
   echo "    info                    gives some information about <service_name>"
   echo
-  echo "    url                     <requires one of the options given below>"
+  echo "    url                     lists both the local and tor url for <service_name>"
   echo "        <local>                 lists the local url for <service_name>"
   echo "        <tor>                   lists the tor url for <service_name>"
-  echo "        <both>                  lists both the local and tor url for <service_name>"
   echo
   echo "    port                    lists the ports used by <service_name>"
   echo

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -427,6 +427,7 @@ function services_help {
   echo
   echo "  Usage:"
   echo "    $BASENAME services <service_name> install"
+  echo "                             ..... cleanup"
   echo "                             ..... up"
   echo "                             ..... down"
   echo "                             ..... start"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.14.24",
+  "version": "1.15.6",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Fixes #833
In favor of ```treehouses services <service_name> url``` to get both instead.
Or we can keep both and do "". 