### PR TITLE
treehouses services couchdb url (fixes #834)

### DIFF
--- a/modules/services.sh
+++ b/modules/services.sh
@@ -258,7 +258,7 @@ function services {
           elif [ "$command_option" = "tor" ]; then
             for i in $(seq 1 "$(get_port $service_name | wc -l)")
             do
-              if tor ; then
+              if [ "$(tor status)" = "active" ]; then
                 tor_url=$(tor)
                 tor_url+=":"
                 tor_url+=$(get_port $service_name | sed -n "$i p")

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -250,6 +250,8 @@ function services {
               local_url+=$(get_port $service_name | sed -n "$i p")
               if [ "$service_name" = "pihole" ]; then
                 local_url+="/admin"
+              elif [ "$service_name" = "couchdb" ]; then
+                local_url+="/_utils"
               fi
               echo $local_url
             done
@@ -261,9 +263,10 @@ function services {
                 tor_url+=":"
                 tor_url+=$(get_port $service_name | sed -n "$i p")
               fi
-
               if [ "$service_name" = "pihole" ]; then
                 tor_url+="/admin"
+              elif [ "$service_name" = "couchdb" ]; then
+                tor_url+="/_utils"
               fi
               echo $tor_url
             done

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.15.0",
+  "version": "1.15.4",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
@@ -24,9 +24,9 @@
     "bluetooth", "ethernet", "wifi", "hotspot", "bridge", "vnc",
     "ntp", "timezone", "rtc", "cron", "backup", "clone",
     "ssh", "sshkey", "sshtunnel", "tor", "openvpn", "coral",
-    "services", "container", "docker", "balena", 
-    "kolibri", "moodle", "netdata", "nextcloud", "ntopng",
-    "pihole", "planet", "portainer", "privatebin", "mastodon", "couchdb"
+    "services", "container", "docker", "balena", "pihole",
+    "kolibri", "moodle", "netdata", "nextcloud", "ntopng", "planet",
+    "portainer", "privatebin", "mastodon", "couchdb", "mariadb"
   ],
   "author": {
     "name": "OLE treehouses team",


### PR DESCRIPTION
Fixes #834

```
root@kjong:~/cli# ./cli.sh services couchdb url both
192.168.1.154:5984/_utils
masrx3fngdcup6cwihvplcgae5c6soppks425jplux24snv3nkfwtxad.onion:5984/_utils
```

Also fixed an issue with getting the tor url.
`if tor ; then` -> `if [ "$(tor status)" = "active" ]; then`