### PR TITLE
treehouses help ap & aphidden noobify (fixes #907)

### DIFF
--- a/modules/ap.sh
+++ b/modules/ap.sh
@@ -83,6 +83,8 @@ function ap_help () {
   echo "Usage: $BASENAME ap <local|internet> <ESSID> [password]"
   echo
   echo "Creates a mobile ap. If the mode is 'internet' the ethernet connection will be shared in the ap."
+  echo "On device connecting to ap must use Gateway and Static IP Address. DHCP isn't supported. e.g."
+  echo "Static IP Address: 192.168.2.2, Gateway: 192.168.2.1 with examples used below:"
   echo
   echo "Examples:"
   echo "  $BASENAME ap local apname apPassword"

--- a/modules/aphidden.sh
+++ b/modules/aphidden.sh
@@ -85,6 +85,9 @@ function aphidden_help () {
   echo "When the Raspberry pi is connected to a network via an ethernet cable this command"
   echo "creates a wireless access point that users can connect to via wifi. If the mode is"
   echo "'internet' the ethernet connection will be shared in the access point."
+  echo "On device please note you must set SSID manually because access point is hidden"
+  echo "On device connecting to ap must use Gateway and Static IP Address. DHCP isn't supported. e.g."
+  echo "Static IP Address: 192.168.2.2, Gateway: 192.168.2.1 with examples used below:"
   echo
   echo "Examples:"
   echo "  $BASENAME aphidden local apname apPassword"


### PR DESCRIPTION
Fixes #907

```
root@raspberrypi:~# git clone http://github.com/treehouses/cli
Cloning into 'cli'...
remote: Enumerating objects: 126, done.
remote: Counting objects: 100% (126/126), done.
remote: Compressing objects: 100% (57/57), done.
remote: Total 3340 (delta 100), reused 80 (delta 69), pack-reused 3214
Receiving objects: 100% (3340/3340), 758.24 KiB | 5.19 MiB/s, done.
Resolving deltas: 100% (2471/2471), done.
root@raspberrypi:~# cd cli
root@raspberrypi:~/cli# clit aphelp
Branch 'aphelp' set up to track remote branch 'aphelp' from 'origin'.
Switched to a new branch 'aphelp'
root@raspberrypi:~/cli# ./cli.sh help ap

Usage: cli.sh ap <local|internet> <ESSID> [password]

Creates a mobile ap. If the mode is 'internet' the ethernet connection will be shared in the ap.
On device connecting to ap must use Gateway and Static IP Address. DHCP isn't supported. e.g.
Static IP Address: 192.168.2.2, Gateway: 192.168.2.1 with examples used below:

Examples:
  cli.sh ap local apname apPassword
      Creates an ap with ESSID 'apname' and password 'apPassword'.
      This hotspot will not share the ethernet connection if present.

  cli.sh ap local apname
      Creates an open ap with ESSID 'apname'.
      This hotspot will not share ethernet connection when present.

  cli.sh ap internet apname apPassword
      Creates an ap with ESSID 'apname' and password 'apPassword'.
      This hotspot will share the ethernet connection when present.

  cli.sh ap internet apname
      Creates an open ap with ESSID 'apname'.
      This hotspot will share the ethernet connection when present.

  This command can be used with the argument '--ip=x.y.z.w' to specify the base ip (x.y.z) for the clients/ap.

  cli.sh ap internet apname --ip=192.168.2.24
      All the clients of this network will have an ip under the network 192.168.2.0

root@raspberrypi:~/cli#

```