### PR TITLE
treehouses help as EOF (fixes #910)

### DIFF
--- a/modules/help.sh
+++ b/modules/help.sh
@@ -1,8 +1,6 @@
 function help_default {
   helpdefault=""
   read -r -d '' helpdefault <<'EOF'
-
-
 Usage: $BASENAME
    help [command]                            gives you a more detailed info about the command or will output this
    verbose <on|off>                          makes each command print more output (might not work with treehouses remote)

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -1,14 +1,14 @@
 function help_default {
   helpdefault=""
   read -r -d '' helpdefault <<'EOF'
-Usage: $BASENAME
+Usage: treehouses
    help [command]                            gives you a more detailed info about the command or will output this
    verbose <on|off>                          makes each command print more output (might not work with treehouses remote)
    expandfs                                  expands the partition of the RPI image to the maximum of the SDcard
    rename <hostname>                         changes hostname
    password <password>                       changes the password for 'pi' user
    sshkey <add|list|delete|deleteall|github> used for adding or removing ssh keys for authentication
-   version                                   returns the version of $BASENAME command
+   version                                   returns the version of treehouses command
    image                                     returns version of the system image installed
    detectbluetooth                           detects if bluetooth module is available
    detectrpi [model]                         detects the hardware version of a raspberry pi
@@ -35,7 +35,7 @@ Usage: $BASENAME
    vnc [on|off|info]                         enables or disables the vnc server service
    default                                   sets a raspbian back to default configuration
    wificountry <country>                     sets the wifi country
-   upgrade                                   upgrades $BASENAME package using npm
+   upgrade                                   upgrades treehouses package using npm
    sshtunnel <add|remove|list|check|notice>  helps adding an sshtunnel
              <key|portinterval> [user@host]
    led [green|red] [mode]                    sets the led mode
@@ -53,7 +53,7 @@ Usage: $BASENAME
    internet                                  checks if the rpi has access to internet
    services [service_name] [command]         executes the given command on the specified service
               [planet]                       Planet Learning is a generic learning system built in Angular & CouchDB
-              [kolibri]                      Kolibri is a learning platform using DJango
+              [kolibri]                      Kolibri is a learning platform using Django
               [nextcloud]                    Nextcloud is a safe home for all your data, files, etc
               [netdata]                      Netdata is a distributed, real-time performance and health monitoring for systems
               [mastodon]                     Mastodon is a free, open-source social network server

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -1,88 +1,92 @@
 function help_default {
-  echo "Usage: $BASENAME"
-  echo
-  echo "   help [command]                            gives you a more detailed info about the command or will output this"
-  echo "   verbose <on|off>                          makes each command print more output (might not work with treehouses remote)"
-  echo "   expandfs                                  expands the partition of the RPI image to the maximum of the SDcard"
-  echo "   rename <hostname>                         changes hostname"
-  echo "   password <password>                       changes the password for 'pi' user"
-  echo "   sshkey <add|list|delete|deleteall|github> used for adding or removing ssh keys for authentication"
-  echo "   version                                   returns the version of $BASENAME command"
-  echo "   image                                     returns version of the system image installed"
-  echo "   detectbluetooth                           detects if bluetooth module is available"
-  echo "   detectrpi [model]                         detects the hardware version of a raspberry pi"
-  echo "   detect                                    detects the hardware version of any device"
-  echo "   ethernet <ip> <mask> <gateway> <dns>      configures rpi network interface to a static ip address"
-  echo "   discover <scan|interface|ping|ports|mac>  performs network scan and discovers all raspberry pis on the network"
-  echo "            <rpi> [ipaddress|url|macaddress]"
-  echo "   wifi <ESSID> [password]                   connects to a wifi network"
-  echo "   wifihidden <ESSID> [password]             connects to a hidden wifi network"
-  echo "   staticwifi <ip> <mask> <gateway> <dns>    configures rpi wifi interface to a static ip address"
-  echo "              <ESSID> [password]"
-  echo "   wifistatus                                displays signal strength in dBm and layman nomenclature"
-  echo "   bridge <ESSID> <hotspotESSID>             configures the rpi to bridge the wlan interface over a hotspot"
-  echo "          [password] [hotspotPassword]"
-  echo "   container <none|docker|balena>            enables (and start) the desired container"
-  echo "   bluetooth <on|off|pause|button|mac|id>    switches bluetooth from regular to hotspot mode and shows id or MAC address"
-  echo "   ap <local|internet> <ESSID> [password]    creates a mobile ap, which has two modes: local (no eth0 bridging), internet (eth0 bridging)"
-  echo "   aphidden <local|internet> <ESSID>         creates a hidden mobile ap, with or without internet access"
-  echo "            [password]"
-  echo "   apchannel [channel]                       sets or prints the current ap channel"
-  echo "   timezone <timezone>                       sets the timezone of the system"
-  echo "   locale <locale>                           sets the system locale"
-  echo "   ssh <on|off>                              enables or disables the ssh service"
-  echo "   vnc [on|off|info]                         enables or disables the vnc server service"
-  echo "   default                                   sets a raspbian back to default configuration"
-  echo "   wificountry <country>                     sets the wifi country"
-  echo "   upgrade                                   upgrades $BASENAME package using npm"
-  echo "   sshtunnel <add|remove|list|check|notice>  helps adding an sshtunnel"
-  echo "             <key|portinterval> [user@host]"
-  echo "   led [green|red] [mode]                    sets the led mode"
-  echo "   rtc <on|off> [rasclock|ds3231]            sets up the rtc clock specified"
-  echo "   ntp <local|internet>                      sets rpi to host timing locally or to get timing from a remote server"
-  echo "   networkmode                               outputs the current network mode"
-  echo "   button <off|bluetooth>                    gives the gpio pin 18 an action"
-  echo "   feedback <message>                        sends feedback"
-  echo "   clone [device path]                       clones the current SDCard onto a secondary SDCard or specified device"
-  echo "   restore [device path]                     restores a treehouses image to an SDCard or specified device"
-  echo "   burn [device path]                        download and burns the latest treehouses image to the SDcard or specified device"
-  echo "   rebootneeded                              shows if reboot is required to apply changes"
-  echo "   reboots <now|in|cron>                     reboots at given frequency | removes it if reboot task active"
-  echo "           <daily|weekly|monthly>"
-  echo "   internet                                  checks if the rpi has access to internet"
-  echo "   services [service_name] [command]         executes the given command on the specified service"
-  echo "              [planet]                       Planet Learning is a generic learning system built in Angular & CouchDB"
-  echo "              [kolibri]                      Kolibri is a learning platform using DJango"
-  echo "              [nextcloud]                    Nextcloud is a safe home for all your data, files, etc"
-  echo "              [netdata]                      Netdata is a distributed, real-time performance and health monitoring for systems"
-  echo "              [mastodon]                     Mastodon is a free, open-source social network server"
-  echo "              [moodle]                       Moodle is a learning management system built in PHP"
-  echo "              [pihole]                       Pi-hole is a DNS sinkhole that protects your devices from unwanted content"
-  echo "              [privatebin]                   PrivateBin is a minimalist, open source online pastebin"
-  echo "              [portainer]                    Portainer is a lightweight management UI for Docker environments"
-  echo "              [ntopng]                       Ntopng is a network traffic probe that monitors network usage"
-  echo "              [couchdb]                      CouchDB is an open-source document-oriented NoSQL database, implemented in Erlang"
-  echo "              [mariadb]                      MariaDB is a community-developed fork of the MySQL relational database management system"
-  echo "              [seafile]                      Seafile is an open-source, cross-platform file-hosting software system"
-  echo "   tor [list|add|delete|deleteall|start]     deals with services on tor hidden network"
-  echo "       [stop|destroy|notice|status|refresh]"
-  echo "   bootoption <console|desktop> [autologin]  sets the boot mode"
-  echo "   openvpn [use|show|delete]                 helps setting up an openvpn client"
-  echo "           [notice|start|stop|load]"
-  echo "   coralenv [install|demo-on|demo-off]       plays with the coral environmental board"
-  echo "            [demo-always-on]"
-  echo "   memory [total|used|free]                  displays the total memory of the device, the memory used as well as the available free memory"
-  echo "   temperature [celsius|fahrenheit]          displays raspberry pi's CPU temperature"
-  echo "   speedtest                                 tests internet download and upload speed"
-  echo "   camera [on|off|capture]                   enables camera, disables camera, captures png photo"
-  echo "   cron [list|add|delete|deleteall]          adds, deletes a custom cron job or deletes, lists all cron jobs"
-  echo "        [0W|tor|timestamp]                   adds premade cron job (or removes it if already active)"
-  echo "   usb [on|off]                              turns usb ports on or off"
-  echo "   remote [status|upgrade|services|version]  helps with treehouses remote android app"
-  echo "   log <0|1|2|3|4|show|max>                  gets/sets log level and shows log"
-  echo "   blocker <0|1|2|3|4||max>                  website blocking levels using /etc/hosts"
-  echo "   sdbench                                   displays read and write speed of micro SD card"
-  echo
+  helpdefault=""
+  read -r -d '' helpdefault <<'EOF'
+
+
+Usage: $BASENAME
+   help [command]                            gives you a more detailed info about the command or will output this
+   verbose <on|off>                          makes each command print more output (might not work with treehouses remote)
+   expandfs                                  expands the partition of the RPI image to the maximum of the SDcard
+   rename <hostname>                         changes hostname
+   password <password>                       changes the password for 'pi' user
+   sshkey <add|list|delete|deleteall|github> used for adding or removing ssh keys for authentication
+   version                                   returns the version of $BASENAME command
+   image                                     returns version of the system image installed
+   detectbluetooth                           detects if bluetooth module is available
+   detectrpi [model]                         detects the hardware version of a raspberry pi
+   detect                                    detects the hardware version of any device
+   ethernet <ip> <mask> <gateway> <dns>      configures rpi network interface to a static ip address
+   discover <scan|interface|ping|ports|mac>  performs network scan and discovers all raspberry pis on the network
+            <rpi> [ipaddress|url|macaddress]
+   wifi <ESSID> [password]                   connects to a wifi network
+   wifihidden <ESSID> [password]             connects to a hidden wifi network
+   staticwifi <ip> <mask> <gateway> <dns>    configures rpi wifi interface to a static ip address
+              <ESSID> [password]
+   wifistatus                                displays signal strength in dBm and layman nomenclature
+   bridge <ESSID> <hotspotESSID>             configures the rpi to bridge the wlan interface over a hotspot
+          [password] [hotspotPassword]
+   container <none|docker|balena>            enables (and start) the desired container
+   bluetooth <on|off|pause|button|mac|id>    switches bluetooth from regular to hotspot mode and shows id or MAC address
+   ap <local|internet> <ESSID> [password]    creates a mobile ap, which has two modes: local (no eth0 bridging), internet (eth0 bridging)
+   aphidden <local|internet> <ESSID>         creates a hidden mobile ap, with or without internet access
+            [password]
+   apchannel [channel]                       sets or prints the current ap channel
+   timezone <timezone>                       sets the timezone of the system
+   locale <locale>                           sets the system locale
+   ssh <on|off>                              enables or disables the ssh service
+   vnc [on|off|info]                         enables or disables the vnc server service
+   default                                   sets a raspbian back to default configuration
+   wificountry <country>                     sets the wifi country
+   upgrade                                   upgrades $BASENAME package using npm
+   sshtunnel <add|remove|list|check|notice>  helps adding an sshtunnel
+             <key|portinterval> [user@host]
+   led [green|red] [mode]                    sets the led mode
+   rtc <on|off> [rasclock|ds3231]            sets up the rtc clock specified
+   ntp <local|internet>                      sets rpi to host timing locally or to get timing from a remote server
+   networkmode                               outputs the current network mode
+   button <off|bluetooth>                    gives the gpio pin 18 an action
+   feedback <message>                        sends feedback
+   clone [device path]                       clones the current SDCard onto a secondary SDCard or specified device
+   restore [device path]                     restores a treehouses image to an SDCard or specified device
+   burn [device path]                        download and burns the latest treehouses image to the SDcard or specified device
+   rebootneeded                              shows if reboot is required to apply changes
+   reboots <now|in|cron>                     reboots at given frequency | removes it if reboot task active
+           <daily|weekly|monthly>
+   internet                                  checks if the rpi has access to internet
+   services [service_name] [command]         executes the given command on the specified service
+              [planet]                       Planet Learning is a generic learning system built in Angular & CouchDB
+              [kolibri]                      Kolibri is a learning platform using DJango
+              [nextcloud]                    Nextcloud is a safe home for all your data, files, etc
+              [netdata]                      Netdata is a distributed, real-time performance and health monitoring for systems
+              [mastodon]                     Mastodon is a free, open-source social network server
+              [moodle]                       Moodle is a learning management system built in PHP
+              [pihole]                       Pi-hole is a DNS sinkhole that protects your devices from unwanted content
+              [privatebin]                   PrivateBin is a minimalist, open source online pastebin
+              [portainer]                    Portainer is a lightweight management UI for Docker environments
+              [ntopng]                       Ntopng is a network traffic probe that monitors network usage
+              [couchdb]                      CouchDB is an open-source document-oriented NoSQL database, implemented in Erlang
+              [mariadb]                      MariaDB is a community-developed fork of the MySQL relational database management system
+              [seafile]                      Seafile is an open-source, cross-platform file-hosting software system
+   tor [list|add|delete|deleteall|start]     deals with services on tor hidden network
+       [stop|destroy|notice|status|refresh]
+   bootoption <console|desktop> [autologin]  sets the boot mode
+   openvpn [use|show|delete]                 helps setting up an openvpn client
+           [notice|start|stop|load]
+   coralenv [install|demo-on|demo-off]       plays with the coral environmental board
+            [demo-always-on]
+   memory [total|used|free]                  displays the total memory of the device, the memory used as well as the available free memory
+   temperature [celsius|fahrenheit]          displays raspberry pi's CPU temperature
+   speedtest                                 tests internet download and upload speed
+   camera [on|off|capture]                   enables camera, disables camera, captures png photo
+   cron [list|add|delete|deleteall]          adds, deletes a custom cron job or deletes, lists all cron jobs
+        [0W|tor|timestamp]                   adds premade cron job (or removes it if already active)
+   usb [on|off]                              turns usb ports on or off
+   remote [status|upgrade|services|version]  helps with treehouses remote android app
+   log <0|1|2|3|4|show|max>                  gets/sets log level and shows log
+   blocker <0|1|2|3|4||max>                  website blocking levels using /etc/hosts
+   sdbench                                   displays read and write speed of micro SD card
+EOF
+  echo "$helpdefault"
 }
 
 function help {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.16.9",
+  "version": "1.16.12",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
```
root@raspberrypi:~/cli# ./cli.sh help
Usage: $BASENAME
   help [command]                            gives you a more detailed info about the command or will output this
   verbose <on|off>                          makes each command print more output (might not work with treehouses remote)
   expandfs                                  expands the partition of the RPI image to the maximum of the SDcard
   rename <hostname>                         changes hostname
   password <password>                       changes the password for 'pi' user
   sshkey <add|list|delete|deleteall|github> used for adding or removing ssh keys for authentication
   version                                   returns the version of $BASENAME command
   image                                     returns version of the system image installed
   detectbluetooth                           detects if bluetooth module is available
   detectrpi [model]                         detects the hardware version of a raspberry pi
   detect                                    detects the hardware version of any device
   ethernet <ip> <mask> <gateway> <dns>      configures rpi network interface to a static ip address
   discover <scan|interface|ping|ports|mac>  performs network scan and discovers all raspberry pis on the network
            <rpi> [ipaddress|url|macaddress]
   wifi <ESSID> [password]                   connects to a wifi network
   wifihidden <ESSID> [password]             connects to a hidden wifi network
   staticwifi <ip> <mask> <gateway> <dns>    configures rpi wifi interface to a static ip address
              <ESSID> [password]
   wifistatus                                displays signal strength in dBm and layman nomenclature
   bridge <ESSID> <hotspotESSID>             configures the rpi to bridge the wlan interface over a hotspot
          [password] [hotspotPassword]
   container <none|docker|balena>            enables (and start) the desired container
   bluetooth <on|off|pause|button|mac|id>    switches bluetooth from regular to hotspot mode and shows id or MAC address
   ap <local|internet> <ESSID> [password]    creates a mobile ap, which has two modes: local (no eth0 bridging), internet (eth0 bridging)
   aphidden <local|internet> <ESSID>         creates a hidden mobile ap, with or without internet access
            [password]
   apchannel [channel]                       sets or prints the current ap channel
   timezone <timezone>                       sets the timezone of the system
   locale <locale>                           sets the system locale
   ssh <on|off>                              enables or disables the ssh service
   vnc [on|off|info]                         enables or disables the vnc server service
   default                                   sets a raspbian back to default configuration
   wificountry <country>                     sets the wifi country
   upgrade                                   upgrades $BASENAME package using npm
   sshtunnel <add|remove|list|check|notice>  helps adding an sshtunnel
             <key|portinterval> [user@host]
   led [green|red] [mode]                    sets the led mode
   rtc <on|off> [rasclock|ds3231]            sets up the rtc clock specified
   ntp <local|internet>                      sets rpi to host timing locally or to get timing from a remote server
   networkmode                               outputs the current network mode
   button <off|bluetooth>                    gives the gpio pin 18 an action
   feedback <message>                        sends feedback
   clone [device path]                       clones the current SDCard onto a secondary SDCard or specified device
   restore [device path]                     restores a treehouses image to an SDCard or specified device
   burn [device path]                        download and burns the latest treehouses image to the SDcard or specified device
   rebootneeded                              shows if reboot is required to apply changes
   reboots <now|in|cron>                     reboots at given frequency | removes it if reboot task active
           <daily|weekly|monthly>
   internet                                  checks if the rpi has access to internet
   services [service_name] [command]         executes the given command on the specified service
              [planet]                       Planet Learning is a generic learning system built in Angular & CouchDB
              [kolibri]                      Kolibri is a learning platform using DJango
              [nextcloud]                    Nextcloud is a safe home for all your data, files, etc
              [netdata]                      Netdata is a distributed, real-time performance and health monitoring for systems
              [mastodon]                     Mastodon is a free, open-source social network server
              [moodle]                       Moodle is a learning management system built in PHP
              [pihole]                       Pi-hole is a DNS sinkhole that protects your devices from unwanted content
              [privatebin]                   PrivateBin is a minimalist, open source online pastebin
              [portainer]                    Portainer is a lightweight management UI for Docker environments
              [ntopng]                       Ntopng is a network traffic probe that monitors network usage
              [couchdb]                      CouchDB is an open-source document-oriented NoSQL database, implemented in Erlang
              [mariadb]                      MariaDB is a community-developed fork of the MySQL relational database management system
              [seafile]                      Seafile is an open-source, cross-platform file-hosting software system
   tor [list|add|delete|deleteall|start]     deals with services on tor hidden network
       [stop|destroy|notice|status|refresh]
   bootoption <console|desktop> [autologin]  sets the boot mode
   openvpn [use|show|delete]                 helps setting up an openvpn client
           [notice|start|stop|load]
   coralenv [install|demo-on|demo-off]       plays with the coral environmental board
            [demo-always-on]
   memory [total|used|free]                  displays the total memory of the device, the memory used as well as the available free memory
   temperature [celsius|fahrenheit]          displays raspberry pi's CPU temperature
   speedtest                                 tests internet download and upload speed
   camera [on|off|capture]                   enables camera, disables camera, captures png photo
   cron [list|add|delete|deleteall]          adds, deletes a custom cron job or deletes, lists all cron jobs
        [0W|tor|timestamp]                   adds premade cron job (or removes it if already active)
   usb [on|off]                              turns usb ports on or off
   remote [status|upgrade|services|version]  helps with treehouses remote android app
   log <0|1|2|3|4|show|max>                  gets/sets log level and shows log
   blocker <0|1|2|3|4||max>                  website blocking levels using /etc/hosts
   sdbench                                   displays read and write speed of micro SD card
root@raspberrypi:~/cli# treehouses help
Usage: treehouses

   help [command]                            gives you a more detailed info about the command or will output this
   verbose <on|off>                          makes each command print more output (might not work with treehouses remote)
   expandfs                                  expands the partition of the RPI image to the maximum of the SDcard
   rename <hostname>                         changes hostname
   password <password>                       changes the password for 'pi' user
   sshkey <add|list|delete|deleteall|github> used for adding or removing ssh keys for authentication
   version                                   returns the version of treehouses command
   image                                     returns version of the system image installed
   detectrpi [model]                         detects the hardware version of a raspberry pi
   detect                                    detects the hardware version of any device
   ethernet <ip> <mask> <gateway> <dns>      configures rpi network interface to a static ip address
   discover <scan|interface|ping|ports|mac>  performs network scan and discovers all raspberry pis on the network
            <rpi> [ipaddress|url|macaddress]
   wifi <ESSID> [password]                   connects to a wifi network
   wifihidden <ESSID> [password]             connects to a hidden wifi network
   staticwifi <ip> <mask> <gateway> <dns>    configures rpi wifi interface to a static ip address
              <ESSID> [password]
   wifistatus                                displays signal strength in dBm and layman nomenclature
   bridge <ESSID> <hotspotESSID>             configures the rpi to bridge the wlan interface over a hotspot
          [password] [hotspotPassword]
   container <none|docker|balena>            enables (and start) the desired container
   bluetooth <on|off|pause|mac|id> [number]  switches bluetooth from regular to hotspot mode and shows id or MAC address
   ap <local|internet> <ESSID> [password]    creates a mobile ap, which has two modes: local (no eth0 bridging), internet (eth0 bridging)
   aphidden <local|internet> <ESSID>         creates a hidden mobile ap, with or without internet access
            [password]
   apchannel [channel]                       sets or prints the current ap channel
   timezone <timezone>                       sets the timezone of the system
   locale <locale>                           sets the system locale
   ssh <on|off>                              enables or disables the ssh service
   vnc [on|off|info]                         enables or disables the vnc server service
   default                                   sets a raspbian back to default configuration
   wificountry <country>                     sets the wifi country
   upgrade                                   upgrades treehouses package using npm
   sshtunnel <add|remove|list|check|notice>  helps adding an sshtunnel
             <key|portinterval> [user@host]
   led [green|red] [mode]                    sets the led mode
   rtc <on|off> [rasclock|ds3231]            sets up the rtc clock specified
   ntp <local|internet>                      sets rpi to host timing locally or to get timing from a remote server
   networkmode                               outputs the current network mode
   button <off|bluetooth>                    gives the gpio pin 18 an action
   feedback <message>                        sends feedback
   clone [device path]                       clones the current SDCard onto a secondary SDCard or specified device
   restore [device path]                     restores a treehouses image to an SDCard or specified device
   burn [device path]                        download and burns the latest treehouses image to the SDcard or specified device
   rebootneeded                              shows if reboot is required to apply changes
   reboots <now|in|cron>                     reboots at given frequency | removes it if reboot task active
           <daily|weekly|monthly>
   internet                                  checks if the rpi has access to internet
   services [service_name] [command]         executes the given command on the specified service
              [planet]                       Planet Learning is a generic learning system built in Angular & CouchDB
              [kolibri]                      Kolibri is a learning platform using DJango
              [nextcloud]                    Nextcloud is a safe home for all your data, files, etc
              [netdata]                      Netdata is a distributed, real-time performance and health monitoring for systems
              [mastodon]                     Mastodon is a free, open-source social network server
              [moodle]                       Moodle is a learning management system built in PHP
              [pihole]                       Pi-hole is a DNS sinkhole that protects your devices from unwanted content
              [privatebin]                   PrivateBin is a minimalist, open source online pastebin
              [portainer]                    Portainer is a lightweight management UI for Docker environments
              [ntopng]                       Ntopng is a network traffic probe that monitors network usage
   tor [list|add|delete|deleteall|start]     deals with services on tor hidden network
       [stop|destroy|notice|status|refresh]
   bootoption <console|desktop> [autologin]  sets the boot mode
   openvpn [use|show|delete]                 helps setting up an openvpn client
           [notice|start|stop|load]
   coralenv [install|demo-on|demo-off]       plays with the coral environmental board
            [demo-always-on]
   memory [total|used|free]                  displays the total memory of the device, the memory used as well as the available free memory
   temperature [celsius|fahrenheit]          displays raspberry pi's CPU temperature
   speedtest                                 tests internet download and upload speed
   camera [on|off|capture]                   enables camera, disables camera, captures png photo
   cron [list|add|delete|deleteall]          adds, deletes a custom cron job or deletes, lists all cron jobs
        [0W|tor|timestamp]                   adds premade cron job (or removes it if already active)
   usb [on|off]                              turns usb ports on or off
   remote [status|upgrade|services|version]  helps with treehouses remote android app
   log <0|1|2|3|4|show|max>                  gets/sets log level and shows log
   blocker <0|1|2|3|4||max>                  website blocking levels using /etc/hosts
   sdbench                                   displays read and write speed of micro SD card

root@raspberrypi:~/cli#

```