### PR TITLE
treehouses tests services <service> icon (fixes #900)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.16.10",
+  "version": "1.16.14",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",

--- a/tests/couchdb.bats
+++ b/tests/couchdb.bats
@@ -93,6 +93,11 @@ load test-helper
   assert_success && assert_output -p 'couchdb stopped and removed'
 }
 
+@test "$clinom services couchdb icon" {
+  run "${clicmd}" services couchdb icon
+  assert_success && assert_output -p 'svg'
+}
+
 @test "$clinom services couchdb cleanup" {
   run "${clicmd}" services couchdb cleanup
   assert_success && assert_output -p 'cleaned up'

--- a/tests/kolibri.bats
+++ b/tests/kolibri.bats
@@ -93,6 +93,11 @@ load test-helper
   assert_success && assert_output -p 'kolibri stopped and removed'
 }
 
+@test "$clinom services kolibri icon" {
+  run "${clicmd}" services kolibri icon
+  assert_success && assert_output -p 'svg'
+}
+
 @test "$clinom services kolibri cleanup" {
   run "${clicmd}" services kolibri cleanup
   assert_success && assert_output -p 'cleaned up'

--- a/tests/mariadb.bats
+++ b/tests/mariadb.bats
@@ -93,6 +93,11 @@ load test-helper
   assert_success && assert_output -p 'mariadb stopped and removed'
 }
 
+@test "$clinom services mariadb icon" {
+  run "${clicmd}" services mariadb icon
+  assert_success && assert_output -p 'svg'
+}
+
 @test "$clinom services mariadb cleanup" {
   run "${clicmd}" services mariadb cleanup
   assert_success && assert_output -p 'cleaned up'

--- a/tests/mastodon.bats
+++ b/tests/mastodon.bats
@@ -93,6 +93,11 @@ load test-helper
   assert_success && assert_output -p 'mastodon stopped and removed'
 }
 
+@test "$clinom services mastodon icon" {
+  run "${clicmd}" services mastodon icon
+  assert_success && assert_output -p 'svg'
+}
+
 @test "$clinom services mastodon cleanup" {
   run "${clicmd}" services mastodon cleanup
   assert_success && assert_output -p 'cleaned up'

--- a/tests/moodle.bats
+++ b/tests/moodle.bats
@@ -93,6 +93,11 @@ load test-helper
   assert_success && assert_output -p 'moodle stopped and removed'
 }
 
+@test "$clinom services moodle icon" {
+  run "${clicmd}" services moodle icon
+  assert_success && assert_output -p 'svg'
+}
+
 @test "$clinom services moodle cleanup" {
   run "${clicmd}" services moodle cleanup
   assert_success && assert_output -p 'cleaned up'

--- a/tests/netdata.bats
+++ b/tests/netdata.bats
@@ -93,6 +93,11 @@ load test-helper
   assert_success && assert_output -p 'netdata stopped and removed'
 }
 
+@test "$clinom services netdata icon" {
+  run "${clicmd}" services netdata icon
+  assert_success && assert_output -p 'svg'
+}
+
 @test "$clinom services netdata cleanup" {
   run "${clicmd}" services netdata cleanup
   assert_success && assert_output -p 'cleaned up'

--- a/tests/nextcloud.bats
+++ b/tests/nextcloud.bats
@@ -93,6 +93,11 @@ load test-helper
   assert_success && assert_output -p 'nextcloud stopped and removed'
 }
 
+@test "$clinom services nextcloud icon" {
+  run "${clicmd}" services nextcloud icon
+  assert_success && assert_output -p 'svg'
+}
+
 @test "$clinom services nextcloud cleanup" {
   run "${clicmd}" services nextcloud cleanup
   assert_success && assert_output -p 'cleaned up'

--- a/tests/ntopng.bats
+++ b/tests/ntopng.bats
@@ -93,6 +93,11 @@ load test-helper
   assert_success && assert_output -p 'ntopng stopped and removed'
 }
 
+@test "$clinom services ntopng icon" {
+  run "${clicmd}" services ntopng icon
+  assert_success && assert_output -p 'svg'
+}
+
 @test "$clinom services ntopng cleanup" {
   run "${clicmd}" services ntopng cleanup
   assert_success && assert_output -p 'cleaned up'

--- a/tests/pihole.bats
+++ b/tests/pihole.bats
@@ -93,6 +93,11 @@ load test-helper
   assert_success && assert_output -p 'pihole stopped and removed'
 }
 
+@test "$clinom services pihole icon" {
+  run "${clicmd}" services pihole icon
+  assert_success && assert_output -p 'svg'
+}
+
 @test "$clinom services pihole cleanup" {
   run "${clicmd}" services pihole cleanup
   assert_success && assert_output -p 'cleaned up'

--- a/tests/portainer.bats
+++ b/tests/portainer.bats
@@ -92,6 +92,11 @@ load test-helper
   assert_success && assert_output -p 'portainer stopped and removed'
 }
 
+@test "$clinom services portainer icon" {
+  run "${clicmd}" services portainer icon
+  assert_success && assert_output -p 'svg'
+}
+
 @test "$clinom services portainer cleanup" {
   run "${clicmd}" services portainer cleanup
   assert_success && assert_output -p 'cleaned up'

--- a/tests/privatebin.bats
+++ b/tests/privatebin.bats
@@ -93,6 +93,11 @@ load test-helper
   assert_success && assert_output -p 'privatebin stopped and removed'
 }
 
+@test "$clinom services privatebin icon" {
+  run "${clicmd}" services privatebin icon
+  assert_success && assert_output -p 'svg'
+}
+
 @test "$clinom services privatebin cleanup" {
   run "${clicmd}" services privatebin cleanup
   assert_success && assert_output -p 'cleaned up'

--- a/tests/seafile.bats
+++ b/tests/seafile.bats
@@ -93,6 +93,11 @@ load test-helper
   assert_success && assert_output -p 'seafile stopped and removed'
 }
 
+@test "$clinom services seafile icon" {
+  run "${clicmd}" services seafile icon
+  assert_success && assert_output -p 'svg'
+}
+
 @test "$clinom services seafile cleanup" {
   run "${clicmd}" services seafile cleanup
   assert_success && assert_output -p 'cleaned up'

--- a/tests/services.bats
+++ b/tests/services.bats
@@ -93,6 +93,11 @@ load test-helper
   assert_success && assert_output -p 'planet stopped and removed'
 }
 
+@test "$clinom services planet icon" {
+  run "${clicmd}" services planet icon
+  assert_success && assert_output -p 'svg'
+}
+
 @test "$clinom services planet cleanup" {
   run "${clicmd}" services planet cleanup
   assert_success && assert_output -p 'cleaned up'


### PR DESCRIPTION
```
root@raspberrypi:~/cli/tests# bats ./services.bats
 ✓  services planet info
 ✓  services planet install
 ✓  services planet up
 ✓  services planet restart
 ✓  services available
 ✓  services available full
 ✓  services running
 ✓  services running full
 ✓  services installed
 ✓  services installed full
 ✓  services ports
 ✓  services planet port
 ✓  services planet ps
 ✗  services planet url both
   (from function `assert_output' in file /usr/lib/node_modules/bats-assert/src/assert.bash, line 247,
    in test file services.bats, line 73)
     `assert_output -p '80'' failed

   -- output does not contain substring --
   substring (1 lines):
     80
   output (2 lines):
     ERROR: unknown command option
     USAGE: cli.sh services url <local | tor>
   --

 ✓  services planet autorun
 ✓  services planet autorun true
 ✓  services planet stop
 ✓  services planet down
 ✓  services planet icon
 ✓  services planet cleanup

20 tests, 1 failure

```