### PR TITLE
treehouses tests services url only (fixes #915)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.16.11",
+  "version": "1.16.13",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",

--- a/tests/couchdb.bats
+++ b/tests/couchdb.bats
@@ -68,8 +68,8 @@ load test-helper
   assert_success && assert_output -p 'treehouses/couchdb'
 }
 
-@test "$clinom services couchdb url both" {
-  run "${clicmd}" services couchdb url both
+@test "$clinom services couchdb url" {
+  run "${clicmd}" services couchdb url
   assert_output -p '5984'
 }
 

--- a/tests/kolibri.bats
+++ b/tests/kolibri.bats
@@ -68,8 +68,8 @@ load test-helper
   assert_success && assert_output -p 'treehouses/kolibri'
 }
 
-@test "$clinom services kolibri url both" {
-  run "${clicmd}" services kolibri url both
+@test "$clinom services kolibri url" {
+  run "${clicmd}" services kolibri url
   assert_output -p '8080'
 }
 

--- a/tests/mariadb.bats
+++ b/tests/mariadb.bats
@@ -68,8 +68,8 @@ load test-helper
   assert_success && assert_output -p 'jsurf/rpi-mariadb'
 }
 
-@test "$clinom services mariadb url both" {
-  run "${clicmd}" services mariadb url both
+@test "$clinom services mariadb url" {
+  run "${clicmd}" services mariadb url
   assert_output -p '3306'
 }
 

--- a/tests/mastodon.bats
+++ b/tests/mastodon.bats
@@ -68,8 +68,8 @@ load test-helper
   assert_success && assert_output -p 'gilir/rpi-mastodon'
 }
 
-@test "$clinom services mastodon url both" {
-  run "${clicmd}" services mastodon url both
+@test "$clinom services mastodon url" {
+  run "${clicmd}" services mastodon url
   assert_output -p '3000'
 }
 

--- a/tests/moodle.bats
+++ b/tests/moodle.bats
@@ -68,8 +68,8 @@ load test-helper
   assert_success && assert_output -p 'treehouses/moodle'
 }
 
-@test "$clinom services moodle url both" {
-  run "${clicmd}" services moodle url both
+@test "$clinom services moodle url" {
+  run "${clicmd}" services moodle url
   assert_output -p '80'
 }
 

--- a/tests/netdata.bats
+++ b/tests/netdata.bats
@@ -68,8 +68,8 @@ load test-helper
   assert_success && assert_output -p 'netdata/netdata'
 }
 
-@test "$clinom services netdata url both" {
-  run "${clicmd}" services netdata url both
+@test "$clinom services netdata url" {
+  run "${clicmd}" services netdata url
   assert_output -p '19999'
 }
 

--- a/tests/nextcloud.bats
+++ b/tests/nextcloud.bats
@@ -68,8 +68,8 @@ load test-helper
   assert_success && assert_output -p 'nextcloud'
 }
 
-@test "$clinom services nextcloud url both" {
-  run "${clicmd}" services nextcloud url both
+@test "$clinom services nextcloud url" {
+  run "${clicmd}" services nextcloud url
   assert_output -p '8081'
 }
 

--- a/tests/ntopng.bats
+++ b/tests/ntopng.bats
@@ -68,8 +68,8 @@ load test-helper
   assert_success && assert_output -p 'jonbackhaus/ntopng'
 }
 
-@test "$clinom services ntopng url both" {
-  run "${clicmd}" services ntopng url both
+@test "$clinom services ntopng url" {
+  run "${clicmd}" services ntopng url
   assert_output -p '8084'
 }
 

--- a/tests/pihole.bats
+++ b/tests/pihole.bats
@@ -68,8 +68,8 @@ load test-helper
   assert_success && assert_output -p 'pihole/pihole'
 }
 
-@test "$clinom services pihole url both" {
-  run "${clicmd}" services pihole url both
+@test "$clinom services pihole url" {
+  run "${clicmd}" services pihole url
   assert_output -p '8053'
 }
 

--- a/tests/portainer.bats
+++ b/tests/portainer.bats
@@ -67,8 +67,8 @@ load test-helper
   assert_success && assert_output -p 'portainer/portainer'
 }
 
-@test "$clinom services portainer url both" {
-  run "${clicmd}" services portainer url both
+@test "$clinom services portainer url" {
+  run "${clicmd}" services portainer url
   assert_output -p '9000'
 }
 

--- a/tests/privatebin.bats
+++ b/tests/privatebin.bats
@@ -68,8 +68,8 @@ load test-helper
   assert_success && assert_output -p 'treehouses/privatebin'
 }
 
-@test "$clinom services privatebin url both" {
-  run "${clicmd}" services privatebin url both
+@test "$clinom services privatebin url" {
+  run "${clicmd}" services privatebin url
   assert_output -p '8083'
 }
 

--- a/tests/seafile.bats
+++ b/tests/seafile.bats
@@ -68,8 +68,8 @@ load test-helper
   assert_success && assert_output -p 'treehouses/rpi-seafile'
 }
 
-@test "$clinom services seafile url both" {
-  run "${clicmd}" services seafile url both
+@test "$clinom services seafile url" {
+  run "${clicmd}" services seafile url
   assert_output -p '8085'
 }
 

--- a/tests/services.bats
+++ b/tests/services.bats
@@ -68,8 +68,8 @@ load test-helper
   assert_success && assert_output -p 'treehouses/planet'
 }
 
-@test "$clinom services planet url both" {
-  run "${clicmd}" services planet url both
+@test "$clinom services planet url" {
+  run "${clicmd}" services planet url
   assert_output -p '80'
 }
 


### PR DESCRIPTION
```
root@raspberrypi:~/cli/tests# bats ./services.bats
 ✓  services planet info
 ✓  services planet install
 ✓  services planet up
 ✓  services planet restart
 ✓  services available
 ✓  services available full
 ✓  services running
 ✓  services running full
 ✓  services installed
 ✓  services installed full
 ✓  services ports
 ✓  services planet port
 ✓  services planet ps
 ✓  services planet url
 ✓  services planet autorun
 ✓  services planet autorun true
 ✓  services planet stop
 ✓  services planet down
 ✓  services planet cleanup

19 tests, 0 failures
root@raspberrypi:~/cli/tests#

```