### PR TITLE
`treehouses services seafile install` work without `tor` (fixes #949)

### DIFF
--- a/services/install-seafile.sh
+++ b/services/install-seafile.sh
@@ -16,7 +16,7 @@ function install {
     echo "      - \"8086:8086\""
     echo "    environment:        "
     echo "      - SEAFILE_NAME=Seafile"
-    echo "      - SEAFILE_ADDRESS=$(treehouses tor) "
+    echo "      - SEAFILE_ADDRESS=$(treehouses tor | grep .onion) "
     echo "      - SEAFILE_ADMIN=example@seafile.com "
     echo "      - SEAFILE_ADMIN_PW=seacret "
     echo "    volumes:          "

--- a/services/install-seafile.sh
+++ b/services/install-seafile.sh
@@ -16,7 +16,7 @@ function install {
     echo "      - \"8086:8086\""
     echo "    environment:        "
     echo "      - SEAFILE_NAME=Seafile"
-    echo "      - SEAFILE_ADDRESS=$(treehouses tor | grep .onion) "
+    echo "      - SEAFILE_ADDRESS="
     echo "      - SEAFILE_ADMIN=example@seafile.com "
     echo "      - SEAFILE_ADMIN_PW=seacret "
     echo "    volumes:          "


### PR DESCRIPTION
EDIT: This defaults to localhost when left blank like this. Worked for me on .onion browser and localhost.

```bash
root@treehouses:~/cli# ./cli.sh services seafile install
Pulling seafile ... done
seafile installed
root@treehouses:~/cli# cat /srv/seafile/*.yml
version: "3"

services:
  seafile:
    image: treehouses/rpi-seafile
    ports:
      - "8085:8000"
      - "8086:8086"
    environment:
      - SEAFILE_NAME=Seafile
      - SEAFILE_ADDRESS=
      - SEAFILE_ADMIN=example@seafile.com
      - SEAFILE_ADMIN_PW=seacret
    volumes:
      - /home/data/seafile:/seafile
root@treehouses:~/cli# ./cli.sh services seafile up
Recreating seafile_seafile_1 ... done
seafile built and started
tor active
8085  <=> 8085
tor active
8086  <=> 8086

```