### PR TITLE
`treehouses detectbluetooth` refactor (fixes #952)(fixes #882)

### DIFF
--- a/modules/detectbluetooth.sh
+++ b/modules/detectbluetooth.sh
@@ -1,6 +1,6 @@
 function detectbluetooth {
   checkargn $# 0
-  if hciconfig hci0 | grep 'No such device' then
+  if hciconfig hci0 | grep 'No such device'; then
     echo "false"
   else
     echo "true"

--- a/modules/detectbluetooth.sh
+++ b/modules/detectbluetooth.sh
@@ -1,9 +1,9 @@
 function detectbluetooth {
   checkargn $# 0
-  if hcitool dev | grep -q 'hci0'; then
-    echo "true"
-  else
+  if hciconfig hci0 | grep 'No such device' then
     echo "false"
+  else
+    echo "true"
   fi
 }
 

--- a/modules/detectbluetooth.sh
+++ b/modules/detectbluetooth.sh
@@ -1,6 +1,6 @@
 function detectbluetooth {
   checkargn $# 0
-  if hciconfig hci0 | grep -q 'No such device'; then
+  if hciconfig hci0 2>&1 | grep -q 'No such device'; then
     echo "false"
   else
     echo "true"

--- a/modules/detectbluetooth.sh
+++ b/modules/detectbluetooth.sh
@@ -1,6 +1,6 @@
 function detectbluetooth {
   checkargn $# 0
-  if hcitool dev | grep -E -o -q ':[^ ]+'; then
+  if hcitool dev | grep -q 'hci0'; then
     echo "true"
   else
     echo "false"

--- a/modules/detectbluetooth.sh
+++ b/modules/detectbluetooth.sh
@@ -1,6 +1,6 @@
 function detectbluetooth {
   checkargn $# 0
-  if hcitool dev | egrep -o -q ':[^ ]+'; then
+  if hcitool dev | grep -E -o -q ':[^ ]+'; then
     echo "true"
   else
     echo "false"

--- a/modules/detectbluetooth.sh
+++ b/modules/detectbluetooth.sh
@@ -1,6 +1,6 @@
 function detectbluetooth {
   checkargn $# 0
-  if dmesg | grep -iq 'blue'; then
+  if hcitool dev | egrep -o -q ':[^ ]+'; then
     echo "true"
   else
     echo "false"

--- a/modules/detectbluetooth.sh
+++ b/modules/detectbluetooth.sh
@@ -1,6 +1,6 @@
 function detectbluetooth {
   checkargn $# 0
-  if hciconfig hci0 | grep 'No such device'; then
+  if hciconfig hci0 | grep -q 'No such device'; then
     echo "false"
   else
     echo "true"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.16.28",
+  "version": "1.17.3",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
- [ ] need to test on Pi without bluetooth adapter