### PR TITLE
`treehouses detectbluetooth` fix longevity (fixes #952) (fixes #862)

### DIFF
--- a/modules/detectbluetooth.sh
+++ b/modules/detectbluetooth.sh
@@ -1,6 +1,6 @@
 function detectbluetooth {
   checkargn $# 0
-  if dmesg | grep -iq 'blue'; then
+  if hcitool dev | egrep -o -q ':[^ ]+'; then
     echo "true"
   else
     echo "false"


### PR DESCRIPTION
- [ ] need to test on Pi without bluetooth adapter