### PR TITLE
`treehouses [-abefhkmnptuvxBCHP] [command]` (fixes #981)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ If you run into any problems check if your RPi is supported [here](https://githu
 ## Features
 
 ```
-Usage: treehouses [-abefhkmnptuvxBCHP] [command] ...
+Usage: treehouses [command] ...
 
-for [-abefhkmnptuvxBCHP] usage check 'set --help'
 
 Commands:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you run into any problems check if your RPi is supported [here](https://githu
 ```
 Usage: treehouses [-abefhkmnptuvxBCHP] [command] ...
 
-dash (-) options are the same as 'set --help'
+for [-abefhkmnptuvxBCHP] usage check 'set --help'
 
 Commands:
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ If you run into any problems check if your RPi is supported [here](https://githu
 ## Features
 
 ```
-Usage: treehouses [command] ...
+Usage: treehouses [-abefhkmnptuvxBCHP] [command] ...
 
+dash (-) options are the same as 'set --help'
 
 Commands:
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ cron [list|add|delete|deleteall]          adds, deletes a custom cron job or del
      [0W|tor|timestamp]                   adds premade cron job (or removes it if already active)
 usb [on|off]                              turns usb ports on or off
 remote [status|upgrade|services]          helps with treehouses remote android app
-log <0|1|2|3|4|show|max>                  gets/sets log level and shows log
+log <0|1|2|3|4|show>                      gets/sets log level and shows log
 blocker <0|1|2|3|4||max>                  website blocking levels using /etc/hosts
 sdbench                                   displays read and write speed of micro SD card
 ```

--- a/_treehouses
+++ b/_treehouses
@@ -169,7 +169,6 @@ treehouses log 1
 treehouses log 2
 treehouses log 3
 treehouses log 4
-treehouses log max
 treehouses log show
 treehouses log show 5
 treehouses memory

--- a/cli.sh
+++ b/cli.sh
@@ -4,6 +4,16 @@ SCRIPTPATH=$(realpath "$0")
 SCRIPTFOLDER=$(dirname "$SCRIPTPATH")
 SCRIPTARGS="$*"
 
+if [[ "$1" == "-"* ]]; then
+  if [ ${#1} -gt 2 ] || [ ${#1} -lt 2 ] || [[ ${1:1} != *[[abefhkmnptuvxBCHP]* ]]; then
+    echo "Error: option not supported please see 'set --help' for available options"
+    exit 1
+  else
+    set "$1"
+    shift
+  fi
+fi
+
 for f in $SCRIPTFOLDER/modules/*.sh
 do
   source "$f"

--- a/cli.sh
+++ b/cli.sh
@@ -6,7 +6,7 @@ SCRIPTARGS="$*"
 
 if [[ "$1" == "-"* ]]; then
   if [ ${#1} -gt 2 ] || [ ${#1} -lt 2 ] || [[ ${1:1} != *[[abefhkmnptuvxBCHP]* ]]; then
-    echo "Error: option not supported please see 'set --help' for available options"
+    echo "Error: $1 option not supported please use [-abefhkmnptuvxBCHP] see 'set --help' for usage"
     exit 1
   else
     set "$1"

--- a/modules/config.sh
+++ b/modules/config.sh
@@ -16,12 +16,6 @@ if [[ -f "$CONFIGFILE" ]]; then
   source "$CONFIGFILE"
 fi
 
-# writes bash trace to screen and to syslog
-if [[ "$LOG" == "max" ]]; then
-  set -x
-  exec 1> >(tee >(logger -t @treehouses/cli)) 2>&1
-fi
-
 # updates config variables "LOG" "1" Requires root
 function conf_var_update() {
   if [[ -f "$CONFIGFILE" && $(cat $CONFIGFILE) = *"$1"* ]]

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -83,7 +83,7 @@ Usage: treehouses
         [0W|tor|timestamp]                   adds premade cron job (or removes it if already active)
    usb [on|off]                              turns usb ports on or off
    remote [status|upgrade|services|version]  helps with treehouses remote android app
-   log <0|1|2|3|4|show|max>                  gets/sets log level and shows log
+   log <0|1|2|3|4|show>                      gets/sets log level and shows log
    blocker <0|1|2|3|4||max>                  website blocking levels using /etc/hosts
    sdbench                                   displays read and write speed of micro SD card
 EOF

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -4,7 +4,7 @@ function help_default {
 
 Usage: treehouses [-abefhkmnptuvxBCHP] [command] ...
 
-dash (-) options are the same as 'set --help'
+for [-abefhkmnptuvxBCHP] usage check 'set --help'
 
 Commands:
 

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -1,7 +1,13 @@
 function help_default {
   helpdefault=""
   read -r -d '' helpdefault <<'EOF'
-Usage: treehouses
+
+Usage: treehouses [-abefhkmnptuvxBCHP] [command] ...
+
+dash (-) options are the same as 'set --help'
+
+Commands:
+
    help [command]                            gives you a more detailed info about the command or will output this
    verbose <on|off>                          makes each command print more output (might not work with treehouses remote)
    expandfs                                  expands the partition of the RPI image to the maximum of the SDcard

--- a/modules/log.sh
+++ b/modules/log.sh
@@ -5,7 +5,7 @@
 # e.g. logit "i am in the log but not written to terminal window" "1"
 # What gets logged depends on the logging level set by log command
 function logit() {
-  if [[ ! "$LOG" == "0" && ! "$LOG" == "max" ]]; then
+  if [[ ! "$LOG" == "0" ]]; then
     case "$3" in
       "")
         logger -p local0.info -t @treehouses/cli "INFO: $1"
@@ -67,9 +67,6 @@ function log {
 	    "4")
 		  logit "log 4: level is set to Info, Warning, Error, and Debug"
 		  ;;
-		"max")
-		  logit "log X: level is set to max"
-		  ;;
 	  esac
       exit 0;
       ;;
@@ -101,12 +98,8 @@ function log {
       fi
 	  grep "@treehouses/cli" /var/log/syslog | tail -n "$lines"
 	  ;;
-	"max")
-	  LOG=max
-	  logit "log X: level set to max" "" "DEBUG"
-	  ;;
     *)
-      log_and_exit1 "Error: only '0' '1' '2' '3' '4' 'show' 'max' options are supported"
+      log_and_exit1 "Error: only '0' '1' '2' '3' '4' 'show' options are supported"
       ;;
   esac
   conf_var_update "LOG" "$LOG"
@@ -114,7 +107,7 @@ function log {
 
 function log_help {
   echo
-  echo "Usage: $BASENAME log <0|1|2|3|4|show|max>"
+  echo "Usage: $BASENAME log <0|1|2|3|4|show>"
   echo
   echo "Example:"
   echo "  $BASENAME log"
@@ -142,8 +135,5 @@ function log_help {
   echo "  $BASENAME log show 5"
   echo "      Shows 5 lines of log which is at (/var/log/syslog)"
   echo "      @treehouses/cli: temperature fahrenheit"
-  echo
-  echo "  $BASENAME log max"
-  echo "      log X: level set to max"
   echo
 }

--- a/tests/log.bats
+++ b/tests/log.bats
@@ -6,11 +6,6 @@ load test-helper
   assert_success && assert_output -p 'log is'
 }
 
-@test "$clinom log max" {
-  run "${clicmd}" log max
-  assert_success && assert_output -p 'log X'
-}
-
 @test "$clinom log 4" {
   run "${clicmd}" log 4
   assert_success && assert_output -p 'log 4'


### PR DESCRIPTION
- Good for testing code in general
- [x] need to test with `treehouses`

```bash
root@treehouses:~/cli/tests# ./test.sh log.bats

Branch  - bashopts
Image   - release-126
Version - 1.17.11

 ✓  log
 ✓  log 4
 ✓  log 3
 ✓  log 2
 ✓  log 1
 ✓  log 0
 ✓  log show
 ✓  log show 5

8 tests, 0 failures

real    0m7.987s
user    0m5.223s
sys     0m2.903s

root@treehouses:~/cli/tests# cd ..
root@treehouses:~/cli# ./cli.sh -- image
Error: -- option not supported please use [-abefhkmnptuvxBCHP] see 'set --help' for usage
root@treehouses:~/cli# ./cli.sh - image
Error: - option not supported please use [-abefhkmnptuvxBCHP] see 'set --help' for usage
root@treehouses:~/cli# ./cli.sh --- image
Error: --- option not supported please use [-abefhkmnptuvxBCHP] see 'set --help' for usage
root@treehouses:~/cli# ./cli.sh -$ image
Error: -$ option not supported please use [-abefhkmnptuvxBCHP] see 'set --help' for usage
root@treehouses:~/cli# ./cli.sh -e image
release-126
root@treehouses:~/cli# ./cli.sh -e services available
couchdb
kolibri
mariadb
mastodon
moodle
netdata
nextcloud
ntopng
pihole
planet
portainer
privatebin
seafile
root@treehouses:~/cli#

```

treehouses tests:
```bash
root@treehouses:~/cli# npm i -g --unsafe-perm ./

> @treehouses/cli@1.17.11 postuninstall /usr/lib/node_modules/@treehouses/cli
> if [ $(id -u) = 0 ]; then rm /etc/bash_completion.d/_treehouses; if [ -f /etc/treehouses.conf ]; then rm /etc/treehouses.conf; fi fi && exit 0

/usr/bin/treehouses -> /usr/lib/node_modules/@treehouses/cli/cli.sh

> @treehouses/cli@1.17.11 postinstall /usr/lib/node_modules/@treehouses/cli
> if [ $(id -u) = 0 ]; then ln -sr _treehouses /etc/bash_completion.d/_treehouses; fi && exit 0

+ @treehouses/cli@1.17.11
updated 1 package in 0.417s
root@treehouses:~/cli# treehouses -e image
release-126
root@treehouses:~/cli# treehouses -- image
Error: -- option not supported please use [-abefhkmnptuvxBCHP] see 'set --help' for usage
root@treehouses:~/cli# treehouses --- image
Error: --- option not supported please use [-abefhkmnptuvxBCHP] see 'set --help' for usage
root@treehouses:~/cli# treehouses - image
Error: - option not supported please use [-abefhkmnptuvxBCHP] see 'set --help' for usage
root@treehouses:~/cli# treehouses -X image
Error: -X option not supported please use [-abefhkmnptuvxBCHP] see 'set --help' for usage
root@treehouses:~/cli# treehouses image
release-126
root@treehouses:~/cli#


```