### PR TITLE
`treehouses networkmode` non-`info` message (fixes #931)

### DIFF
--- a/modules/networkmode.sh
+++ b/modules/networkmode.sh
@@ -64,7 +64,7 @@ function networkmode {
       done
     fi
   else
-    echo "$network_mode"
+    networkmode_help
   fi
 }
 

--- a/modules/networkmode.sh
+++ b/modules/networkmode.sh
@@ -65,6 +65,7 @@ function networkmode {
     fi
   else
     networkmode_help
+    exit 1
   fi
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.17.14",
+  "version": "1.17.16",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
networkmode.sh has been modified to avoid error