### PR TITLE
`treehouses` subcommands without `eval` (fixes #1032)

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -40,7 +40,7 @@ do
   fi
 done
 if [ "$find" = 1 ]; then
-  eval "$@"
+  ($@)
 else
   help
 fi

--- a/cli.sh
+++ b/cli.sh
@@ -40,7 +40,7 @@ do
   fi
 done
 if [ "$find" = 1 ]; then
-  $@
+  "$@"
 else
   help
 fi

--- a/cli.sh
+++ b/cli.sh
@@ -40,7 +40,7 @@ do
   fi
 done
 if [ "$find" = 1 ]; then
-  ($@)
+  $@
 else
   help
 fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.17.19",
+  "version": "1.18.1",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
This fixes problems with eval because eval does 2 passes over its input. This is best solution I could find. Needs some testing Cheers.
tests:
```bash
root@treehouses:~/cli/tests# yes | ./test.sh all

Branch  - fixreports
Image   - release-126
Version - 1.17.19

1..466
ok 1  ap local test1 (check ap...press any key to continue)
ok 2  ap local test2 password (check ap...press any key to continue)
ok 3  ap internet test3 (check ap...press any key to continue)
ok 4  ap internet test4 password (check ap...press any key to continue)
ok 5  ap internet test5 password --ip=192.168.2.24 (check ap...press any key to continue)
not ok 6  apchannel
# (from function `assert_success' in file /usr/lib/node_modules/bats-assert/src/assert.bash, line 114,
#  in test file apchannel.bats, line 7)
#   `assert_success' failed
#
# -- command failed --
# status : 1
# output (11 lines):
#   Error: the current network mode (
#   Usage: cli.sh networkmode [info]
#
#   Outputs the current network mode
#
#   Example:
#     cli.sh networkmode
#         Will output the current network mode that has been set up using cli.sh
#
#     cli.sh networkmode info
#         shows the current status of the network mode) has no config for channel
# --
#
not ok 7  apchannel 6
# (from function `assert_success' in file /usr/lib/node_modules/bats-assert/src/assert.bash, line 113,
#  in test file apchannel.bats, line 13)
#   `assert_success && assert_output -p 'Success'' failed
#
# -- command failed --
# status : 1
# output (11 lines):
#   Error: the current network mode (
#   Usage: cli.sh networkmode [info]
#
#   Outputs the current network mode
#
#   Example:
#     cli.sh networkmode
#         Will output the current network mode that has been set up using cli.sh
#
#     cli.sh networkmode info
#         shows the current status of the network mode) has no config for channel
# --
#
ok 8  aphidden local test123 (check ap...press any key to continue)
ok 9  aphidden local test123 password (check ap...press any key to continue)
ok 10  aphidden internet test321 (check ap...press any key to continue)
ok 11  aphidden internet test321 password (check ap...press any key to continue)
ok 12  aphidden internet test321 password --ip=192.168.2.24 (check ap...press any key to continue)
ok 13  blocker
ok 14  blocker max
ok 15  blocker 4
ok 16  blocker 3
ok 17  blocker 2
ok 18  blocker 1
ok 19  blocker 0
ok 20  bluetooth off
ok 21  bluetooth pause
ok 22  bluetooth on
ok 23  bluetooth mac
ok 24  bluetooth id
ok 25  bluetooth id number
ok 26  bootoption console
ok 27  bootoption console autologin
ok 28  bootoption desktop
ok 29  bootoption desktop autologin
ok 30  bridge (manually test w/out bats - requires reboots)
ok 31 # skip (No disk/usb device mounted)  burn (/dev/sdb will take a while)
ok 32  button off
ok 33  button bluetooth (check button...press any key to continue)
ok 34  camera (manually test w/out bats - requires reboots)
ok 35 # skip (No disk/usb device mounted)  clone (/dev/sdb will take a while)
ok 36  container
ok 37  container balena
ok 38  container none
ok 39  container docker
ok 40  coralenv (manually test w/out bats - requires coral environmental sensor board)
ok 41  cron tor
ok 42  cron timestamp
ok 43  cron 0W
ok 44  cron list
ok 45  default
ok 46  default network
ok 47  default tunnel
ok 48  default notice
ok 49  detect
ok 50  detectarm
ok 51  detectbluetooth
ok 52  detectrpi
ok 53  detectrpi model
ok 54  discover rpi
ok 55  discover scan google.com (manually test w/out bats - takes time)
ok 56  discover scan scanme.nmap.org (manually test w/out bats - takes time)
ok 57  discover interface
ok 58  discover ping google.com
ok 59  discover ports localhost
ok 60  discover mac b8:29:eb:9f:42:8b
ok 61  ethernet (manually test w/out bats - may cause disconnect)
ok 62  expandfs
ok 63  feedback
ok 64  help
ok 65  help apchannel
ok 66  help aphidden
ok 67  help ap
ok 68  help blocker
ok 69  help bluetooth
ok 70  help bootoption
ok 71  help bridge
ok 72  help burn
ok 73  help button
ok 74  help camera
ok 75  help clone
ok 76  help container
ok 77  help coralenv
ok 78  help cron
ok 79  help default
ok 80  help detectrpi
ok 81  help detect
ok 82  help discover
ok 83  help ethernet
ok 84  help expandfs
ok 85  help feedback
ok 86  help image
ok 87  help internet
ok 88  help led
ok 89  help locale
ok 90  help log
ok 91  help memory
ok 92  help networkmode
ok 93  help ntp
ok 94  help openvpn
ok 95  help password
ok 96  help rebootneeded
ok 97  help reboots
ok 98  help remote
ok 99  help rename
ok 100  help restore
ok 101  help rtc
ok 102  help sdbench
ok 103  help services
ok 104  help speedtest
ok 105  help sshkey
ok 106  help ssh
ok 107  help sshtunnel
ok 108  help staticwifi
ok 109  help temperature
ok 110  help timezone
ok 111  help tor
ok 112  help upgrade
ok 113  help usb
ok 114  help verbose
ok 115  help version
ok 116  help vnc
ok 117  help wificountry
ok 118  help wifihidden
ok 119  help wifi
ok 120  help wifistatus
ok 121  image
ok 122  internet
ok 123  led green heartbeat
ok 124  led red default-on
ok 125  led
ok 126  led red
ok 127  led dance
ok 128  led thanksgiving
ok 129  led christmas
ok 130  led lunarnewyear
ok 131  led valentine
ok 132  led carnival
ok 133  led onam
ok 134  locale en_US
ok 135  log
ok 136  log max
ok 137  log 4
ok 138  log 3
ok 139  log 2
ok 140  log 1
ok 141  log 0
ok 142  log show
ok 143  log show 5
ok 144  memory
ok 145  memory -g
ok 146  memory total
ok 147  memory used
ok 148  memory free -m
not ok 149  networkmode
# (from function `assert_success' in file /usr/lib/node_modules/bats-assert/src/assert.bash, line 114,
#  in test file networkmode.bats, line 6)
#   `assert_success' failed
#
# -- command failed --
# status : 1
# output (11 lines):
#
#   Usage: cli.sh networkmode [info]
#
#   Outputs the current network mode
#
#   Example:
#     cli.sh networkmode
#         Will output the current network mode that has been set up using cli.sh
#
#     cli.sh networkmode info
#         shows the current status of the network mode
# --
#
ok 150  networkmode info
ok 151  ntp internet
ok 152  ntp local
ok 153  openvpn (manually test w/out bats - requires ovpn config file)
ok 154  password raspberry
ok 155  rebootneeded
ok 156  reboots now (manually test w/out bats - requires reboots)
ok 157  reboots in (manually test w/out bats - requires reboots)
ok 158  reboots daily
ok 159  reboots weekly
ok 160  reboots monthly
ok 161  reboots cron "0 * * * *"
ok 162  remote status
ok 163  remote upgrade
ok 164  remote services available
ok 165  remote version 2060
ok 166  remote commands
ok 167  rename treehouses
ok 168 # skip (No disk/usb device mounted)  restore (/dev/sdb will take a while)
ok 169  rtc on rasclock
ok 170  rtc on ds3231
ok 171  rtc off
ok 172  services planet info
ok 173  services planet install
ok 174  services planet up
ok 175  services planet restart
ok 176  services available
ok 177  services running
ok 178  services running full
ok 179  services installed
ok 180  services installed full
ok 181  services ports
ok 182  services planet port
ok 183  services planet ps
ok 184  services planet url
ok 185  services planet autorun
ok 186  services planet autorun true
ok 187  services planet stop
ok 188  services planet down
ok 189  services planet icon
ok 190  services planet cleanup
ok 191  speedtest
ok 192  speedtest -h
ok 193  ssh (manually test w/out bats - requires reboots)
ok 194  sshkey add "test"
ok 195  sshkey list
ok 196  sshkey delete "test"
ok 197  sshkey deleteall (manually test w/out bats - deletes all sshkeys)
ok 198  sshkey github adduser dogi
ok 199  sshkey github deleteuser dogi
ok 200  sshkey github addteam (manually test w/out bats - needs access token)
ok 201  sshtunnel (manually test w/out bats - requires dest address)
ok 202  staticwifi (manually test w/out bats - may need further config)
ok 203  temperature
ok 204  temperature fahrenheit
ok 205  temperature celsius
ok 206  temperature kelvin
ok 207  timezone Etc/GMT-3
ok 208  tor add 22
ok 209  tor start
ok 210  tor list
ok 211  tor status
ok 212  tor refresh
ok 213  tor stop
ok 214  tor delete 22
ok 215  tor start
ok 216  tor
ok 217  tor add 22
ok 218  tor notice now
ok 219  upgrade 1.14.0
ok 220  upgrade --check
ok 221  upgrade -f
ok 222  upgrade
ok 223  usb (manually test w/out bats - sometimes hangs)
ok 224  verbose
ok 225  verbose on
ok 226  verbose off
ok 227  version
ok 228  vnc
ok 229  vnc off
ok 230  vnc on
ok 231  vnc info
ok 232 # skip (Wifi pass is present in test.sh)  wifi YOUR-WIFI-NAME
ok 233 # skip (No wifi settings set in test.sh)  wifi YOUR-WIFI-NAME YOUR-WIFI-PASS
ok 234  wificountry US
ok 235  wificountry
ok 236 # skip (Wifi pass is present in test.sh)  wifihidden YOUR-WIFI-NAME
ok 237 # skip (No wifi settings set in test.sh)  wifihidden YOUR-WIFI-NAME YOUR-WIFI-PASS
ok 238  wifistatus
ok 239  services couchdb info
ok 240  services couchdb install
ok 241  services couchdb up
ok 242  services couchdb restart
ok 243  services available
ok 244  services running
ok 245  services running full
ok 246  services installed
ok 247  services installed full
ok 248  services ports
ok 249  services couchdb port
ok 250  services couchdb ps
ok 251  services couchdb url
ok 252  services couchdb autorun
ok 253  services couchdb autorun true
ok 254  services couchdb stop
ok 255  services couchdb down
ok 256  services couchdb icon
ok 257  services couchdb cleanup
ok 258  services kolibri info
ok 259  services kolibri install
ok 260  services kolibri up
ok 261  services kolibri restart
ok 262  services available
ok 263  services running
ok 264  services running full
ok 265  services installed
ok 266  services installed full
ok 267  services ports
ok 268  services kolibri port
ok 269  services kolibri ps
ok 270  services kolibri url
ok 271  services kolibri autorun
ok 272  services kolibri autorun true
ok 273  services kolibri stop
ok 274  services kolibri down
ok 275  services kolibri icon
ok 276  services kolibri cleanup
ok 277  services mariadb info
ok 278  services mariadb install
ok 279  services mariadb up
ok 280  services mariadb restart
ok 281  services available
ok 282  services running
ok 283  services running full
ok 284  services installed
ok 285  services installed full
ok 286  services ports
ok 287  services mariadb port
ok 288  services mariadb ps
ok 289  services mariadb url
ok 290  services mariadb autorun
ok 291  services mariadb autorun true
ok 292  services mariadb stop
ok 293  services mariadb down
ok 294  services mariadb icon
ok 295  services mariadb cleanup
ok 296  services mastodon info
ok 297  services mastodon install
ok 298  services mastodon up
ok 299  services mastodon restart
ok 300  services available
ok 301  services running
ok 302  services running full
ok 303  services installed
ok 304  services installed full
ok 305  services ports
ok 306  services mastodon port
ok 307  services mastodon ps
ok 308  services mastodon url
ok 309  services mastodon autorun
ok 310  services mastodon autorun true
ok 311  services mastodon stop
ok 312  services mastodon down
ok 313  services mastodon icon
ok 314  services mastodon cleanup
ok 315  services moodle info
ok 316  services moodle install
ok 317  services moodle up
ok 318  services moodle restart
ok 319  services available
ok 320  services running
ok 321  services running full
ok 322  services installed
ok 323  services installed full
ok 324  services ports
ok 325  services moodle port
ok 326  services moodle ps
ok 327  services moodle url
ok 328  services moodle autorun
ok 329  services moodle autorun true
ok 330  services moodle stop
ok 331  services moodle down
ok 332  services moodle icon
ok 333  services moodle cleanup
ok 334  services netdata info
ok 335  services netdata install
ok 336  services netdata up
ok 337  services netdata restart
ok 338  services available
ok 339  services running
ok 340  services running full
ok 341  services installed
ok 342  services installed full
ok 343  services ports
ok 344  services netdata port
ok 345  services netdata ps
ok 346  services netdata url
ok 347  services netdata autorun
ok 348  services netdata autorun true
ok 349  services netdata stop
ok 350  services netdata down
ok 351  services netdata icon
ok 352  services netdata cleanup
ok 353  services nextcloud info
ok 354  services nextcloud install
ok 355  services nextcloud up
ok 356  services nextcloud restart
ok 357  services available
ok 358  services running
ok 359  services running full
ok 360  services installed
ok 361  services installed full
ok 362  services ports
ok 363  services nextcloud port
ok 364  services nextcloud ps
ok 365  services nextcloud url
ok 366  services nextcloud autorun
ok 367  services nextcloud autorun true
ok 368  services nextcloud stop
ok 369  services nextcloud down
ok 370  services nextcloud icon
ok 371  services nextcloud cleanup
ok 372  services ntopng info
ok 373  services ntopng install
ok 374  services ntopng up
ok 375  services ntopng restart
ok 376  services available
ok 377  services running
ok 378  services running full
ok 379  services installed
ok 380  services installed full
ok 381  services ports
ok 382  services ntopng port
ok 383  services ntopng ps
ok 384  services ntopng url
ok 385  services ntopng autorun
ok 386  services ntopng autorun true
ok 387  services ntopng stop
ok 388  services ntopng down
ok 389  services ntopng icon
ok 390  services ntopng cleanup
ok 391  services pihole info
ok 392  services pihole install
ok 393  services pihole up
ok 394  services pihole restart
ok 395  services available
ok 396  services running
ok 397  services running full
ok 398  services installed
ok 399  services installed full
ok 400  services ports
ok 401  services pihole port
ok 402  services pihole ps
ok 403  services pihole url
ok 404  services pihole autorun
ok 405  services pihole autorun true
ok 406  services pihole stop
ok 407  services pihole down
ok 408  services pihole icon
ok 409  services pihole cleanup
ok 410  services portainer info
ok 411  services portainer install
ok 412  services portainer up
ok 413  services portainer restart
ok 414  services available
ok 415  services running
ok 416  services running full
ok 417  services installed
ok 418  services installed full
ok 419  services ports
ok 420  services portainer port
ok 421  services portainer ps
ok 422  services portainer url
ok 423  services portainer autorun
ok 424  services portainer autorun true
ok 425  services portainer stop
ok 426  services portainer down
ok 427  services portainer icon
ok 428  services portainer cleanup
ok 429  services privatebin info
ok 430  services privatebin install
ok 431  services privatebin up
ok 432  services privatebin restart
ok 433  services available
ok 434  services running
ok 435  services running full
ok 436  services installed
ok 437  services installed full
ok 438  services ports
ok 439  services privatebin port
ok 440  services privatebin ps
ok 441  services privatebin url
ok 442  services privatebin autorun
ok 443  services privatebin autorun true
ok 444  services privatebin stop
ok 445  services privatebin down
ok 446  services privatebin icon
ok 447  services privatebin cleanup
not ok 448  services seafile info
# (from function `assert_output' in file /usr/lib/node_modules/bats-assert/src/assert.bash, line 247,
#  in test file services/seafile.bats, line 6)
#   `assert_success && assert_output -p 'https://github.com/treehouses/seafile'' failed
#
# -- output does not contain substring --
# substring (1 lines):
#   https://github.com/treehouses/seafile
# output (6 lines):
#   https://github.com/treehouses/rpi-seafile
#
#   "Seafile is an open source file sync&share solution designed for
#   high reliability, performance and productivity. Sync, share and
#   collaborate across devices and teams. Build your team's knowledge
#   base with Seafile's built-in Wiki feature. https://www.seafile.com/"
# --
#
ok 449  services seafile install
ok 450  services seafile up
ok 451  services seafile restart
ok 452  services available
ok 453  services running
ok 454  services running full
ok 455  services installed
ok 456  services installed full
ok 457  services ports
ok 458  services seafile port
ok 459  services seafile ps
ok 460  services seafile url
ok 461  services seafile autorun
ok 462  services seafile autorun true
ok 463  services seafile stop
ok 464  services seafile down
ok 465  services seafile icon
ok 466  services seafile cleanup

real    34m54.030s
user    8m22.059s
sys     4m29.462s

root@treehouses:~/cli/tests#

```