### PR TITLE
`treehouses services available` based on arm type (fixes #1028)

### DIFF
--- a/modules/services.sh
+++ b/modules/services.sh
@@ -88,13 +88,6 @@ function services {
       exit 1
     else
       check_available_services $service_name
-      check_arm $service_name
-      if ! check_arm $service_name; then
-        echo "ERROR: unsupported arm"
-        echo "user arm: $(detectarm)"
-        echo "supported arm(s): ${arms[*]}"
-        exit 1
-      fi
       case "$command" in
         install)
           checkargn $# 2
@@ -402,10 +395,6 @@ function check_arm {
       return 0
     fi
   done
-  # echo "ERROR: unsupported arm"
-  # echo "user arm: $(detectarm)"
-  # echo "supported arm(s): ${arms[*]}"
-  # exit 1
   return 1
 }
 

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -12,7 +12,10 @@ function services {
       for file in $SERVICES/*
       do
         if [[ ! $file = *"README.md"* ]]; then
-          echo "${file##*/}" | sed -e 's/^install-//' -e 's/.sh$//'
+          service=$(echo "${file##*/}" | sed -e 's/^install-//' -e 's/.sh$//')
+          if check_arm $service; then
+            echo $service
+          fi
         fi
       done
     else
@@ -86,6 +89,12 @@ function services {
     else
       check_available_services $service_name
       check_arm $service_name
+      if ! check_arm $service_name; then
+        echo "ERROR: unsupported arm"
+        echo "user arm: $(detectarm)"
+        echo "supported arm(s): ${arms[*]}"
+        exit 1
+      fi
       case "$command" in
         install)
           checkargn $# 2
@@ -393,11 +402,11 @@ function check_arm {
       return 0
     fi
   done
-  echo "ERROR: unsupported arm"
-  echo "user arm: $(detectarm)"
-  echo "supported arm(s): ${arms[*]}"
-  exit 1
-  # return 1
+  # echo "ERROR: unsupported arm"
+  # echo "user arm: $(detectarm)"
+  # echo "supported arm(s): ${arms[*]}"
+  # exit 1
+  return 1
 }
 
 function check_available_services {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.17.19",
+  "version": "1.17.21",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Fixes #1028

Before:
```
root@lilyxxx0w:~/cli# ./cli.sh services available
couchdb
kolibri
mariadb
mastodon
moodle
netdata
nextcloud
ntopng
pihole
planet
portainer
privatebin
seafile
```

After:
```
root@lilyxxx0w:~/cli# ./cli.sh services available
couchdb
mariadb
netdata
pihole
planet
portainer
privatebin
seafile
```

Also removed `check_arm` at line 88 since any incompatible services are being removed in `check_available_services` (which calls `services available` which calls `check_arm`)