### PR TITLE
`treehouses bluetooth status` (fixes #1048)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ bridge <ESSID> <hotspotESSID>             configures the rpi to bridge the wlan 
        [password] [hotspotPassword]
 config [update|add|delete|clear]          commands for interacting with config file
 container <none|docker|balena>            enables (and start) the desired container
-bluetooth <on|off|pause|button|mac|id     switches bluetooth from regular to hotspot mode and shows id or MAC address
-            |status>                   
+bluetooth <on|off|pause|button|mac|id>    switches bluetooth from regular to hotspot mode and shows id or MAC address
+          <status>                   
 ap <local|internet> <ESSID> [password]    creates a mobile ap, which has two modes: local (no eth0 bridging), internet (eth0 bridging)
 aphidden <local|internet> <ESSID>         creates a hidden mobile ap with or without internet access
          [password]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ bridge <ESSID> <hotspotESSID>             configures the rpi to bridge the wlan 
 config [update|add|delete|clear]          commands for interacting with config file
 container <none|docker|balena>            enables (and start) the desired container
 bluetooth <on|off|pause|button|mac|id     switches bluetooth from regular to hotspot mode and shows id or MAC address
-            |source>                   
+            |status>                   
 ap <local|internet> <ESSID> [password]    creates a mobile ap, which has two modes: local (no eth0 bridging), internet (eth0 bridging)
 aphidden <local|internet> <ESSID>         creates a hidden mobile ap with or without internet access
          [password]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ bridge <ESSID> <hotspotESSID>             configures the rpi to bridge the wlan 
        [password] [hotspotPassword]
 config [update|add|delete|clear]          commands for interacting with config file
 container <none|docker|balena>            enables (and start) the desired container
-bluetooth <on|off|pause|button|mac|id>    switches bluetooth from regular to hotspot mode and shows id or MAC address
+bluetooth <on|off|pause|button|mac|id     switches bluetooth from regular to hotspot mode and shows id or MAC address
+            |source>                   
 ap <local|internet> <ESSID> [password]    creates a mobile ap, which has two modes: local (no eth0 bridging), internet (eth0 bridging)
 aphidden <local|internet> <ESSID>         creates a hidden mobile ap with or without internet access
          [password]

--- a/_treehouses
+++ b/_treehouses
@@ -24,6 +24,7 @@ treehouses bluetooth mac
 treehouses bluetooth off
 treehouses bluetooth on
 treehouses bluetooth pause
+treehouses bluetooth status
 treehouses bootoption console
 treehouses bootoption console autologin
 treehouses bootoption desktop

--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -7,9 +7,14 @@ function bluetooth {
 
   if [ -z "$status" ]; then
     if [[ "$(service rpibluetooth status | grep "Active:")" =~ "running" ]]; then
-      echo "on"
+      echo "rpibluetooth service status: on"
     else
-      echo "off"
+      echo "rpibluetooth service status: off"
+    fi
+    if [[ "$(service bluetooth status | grep "Active:")" =~ "running" ]]; then
+      echo "bluetooth service status: on"
+    else
+      echo "bluetooth service status: off"
     fi
 
   elif [ "$status" = "on" ]; then
@@ -76,7 +81,8 @@ function bluetooth_help {
   echo
   echo "Example:"
   echo "  $BASENAME bluetooth"
-  echo "      off"
+  echo "      rpibluetooth service status: on"
+  echo "      bluetooth service status: on"
   echo 
   echo "  $BASENAME bluetooth on"
   echo "      This will start the bluetooth server, which lets the user control the raspberry pi using the mobile app."

--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -7,14 +7,21 @@ function bluetooth {
 
   if [ -z "$status" ]; then
     if [[ "$(service rpibluetooth status | grep "Active:")" =~ "running" ]]; then
-      echo "rpibluetooth service status: on"
+      echo "on"
     else
-      echo "rpibluetooth service status: off"
+      echo "off"
     fi
+
+  elif [ "$status" = "status" ]; then
     if [[ "$(service bluetooth status | grep "Active:")" =~ "running" ]]; then
       echo "bluetooth service status: on"
     else
       echo "bluetooth service status: off"
+    fi
+    if [[ "$(service rpibluetooth status | grep "Active:")" =~ "running" ]]; then
+      echo "rpibluetooth service status: on"
+    else
+      echo "rpibluetooth service status: off"
     fi
 
   elif [ "$status" = "on" ]; then
@@ -81,8 +88,11 @@ function bluetooth_help {
   echo
   echo "Example:"
   echo "  $BASENAME bluetooth"
-  echo "      rpibluetooth service status: on"
+  echo "      on"
+  echo
+  echo "  $BASENAME bluetooth status"
   echo "      bluetooth service status: on"
+  echo "      rpibluetooth service status: on"
   echo 
   echo "  $BASENAME bluetooth on"
   echo "      This will start the bluetooth server, which lets the user control the raspberry pi using the mobile app."

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -26,8 +26,8 @@ Usage: treehouses
           [password] [hotspotPassword]
    config [update|add|delete|clear]          commands for interacting with config file
    container <none|docker|balena>            enables (and start) the desired container
-   bluetooth <on|off|pause|button|mac|id    switches bluetooth from regular to hotspot mode and shows id or MAC address
-                |status>
+   bluetooth <on|off|pause|button|mac|id>    switches bluetooth from regular to hotspot mode and shows id or MAC address
+             <status>
    ap <local|internet> <ESSID> [password]    creates a mobile ap, which has two modes: local (no eth0 bridging), internet (eth0 bridging)
    aphidden <local|internet> <ESSID>         creates a hidden mobile ap, with or without internet access
             [password]

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -26,7 +26,8 @@ Usage: treehouses
           [password] [hotspotPassword]
    config [update|add|delete|clear]          commands for interacting with config file
    container <none|docker|balena>            enables (and start) the desired container
-   bluetooth <on|off|pause|button|mac|id>    switches bluetooth from regular to hotspot mode and shows id or MAC address
+   bluetooth <on|off|pause|button|mac|id    switches bluetooth from regular to hotspot mode and shows id or MAC address
+                |status>
    ap <local|internet> <ESSID> [password]    creates a mobile ap, which has two modes: local (no eth0 bridging), internet (eth0 bridging)
    aphidden <local|internet> <ESSID>         creates a hidden mobile ap, with or without internet access
             [password]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.18.5",
+  "version": "1.18.8",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Fixes #1048

`treehouses bluetooth` status output updated