### PR TITLE
`treehouses bluetooth log` add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ bridge <ESSID> <hotspotESSID>             configures the rpi to bridge the wlan 
        [password] [hotspotPassword]
 config [update|add|delete|clear]          commands for interacting with config file
 container <none|docker|balena>            enables (and start) the desired container
-bluetooth <on|off|pause|button|mac|id>    switches bluetooth from regular to hotspot mode and shows id or MAC address
+bluetooth [on|off|pause|button|mac|id]    switches bluetooth from regular to hotspot mode and shows id or MAC address
+          [log]
 ap <local|internet> <ESSID> [password]    creates a mobile ap, which has two modes: local (no eth0 bridging), internet (eth0 bridging)
 aphidden <local|internet> <ESSID>         creates a hidden mobile ap with or without internet access
          [password]

--- a/_treehouses
+++ b/_treehouses
@@ -20,6 +20,7 @@ treehouses blocker max
 treehouses bluetooth button
 treehouses bluetooth id
 treehouses bluetooth id number
+treehouses bluetooth log
 treehouses bluetooth mac
 treehouses bluetooth off
 treehouses bluetooth on

--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -63,14 +63,19 @@ function bluetooth {
    elif [ "$status" = "button" ]; then
      button bluetooth
 
+   elif [ "$status" = "log" ]; then
+     checkargn $# 1
+     echo "press (ctrl+c) to cancel"
+     journalctl -u rpibluetooth -u bluetooth -f
+
   else
-    echo "Error: only 'on', 'off', 'pause' options are supported";
+    echo "Error: only 'on', 'off', 'pause', 'mac', 'id', 'button', 'log' options are supported";
   fi
 }
 
 function bluetooth_help {
   echo
-  echo "Usage: $BASENAME bluetooth <on|off|pause|mac|id|button>"
+  echo "Usage: $BASENAME bluetooth <on|off|pause|mac|id|button|log>"
   echo
   echo "Switches between hotspot / regular bluetooth mode, or displays the bluetooth mac address"
   echo
@@ -101,5 +106,9 @@ function bluetooth_help {
   echo
   echo "  $BASENAME bluetooth id number"
   echo "      This will display the bluetooth id number"
+  echo
+  echo "  $BASENAME bluetooth log"
+  echo "      This will follow and display the real time logs of bluetooth services"
+  echo "      (ctrl+c) to cancel"
   echo
 }

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -26,7 +26,8 @@ Usage: treehouses
           [password] [hotspotPassword]
    config [update|add|delete|clear]          commands for interacting with config file
    container <none|docker|balena>            enables (and start) the desired container
-   bluetooth <on|off|pause|button|mac|id>    switches bluetooth from regular to hotspot mode and shows id or MAC address
+   bluetooth [on|off|pause|button|mac|id]    switches bluetooth from regular to hotspot mode and shows id or MAC address
+             [log]
    ap <local|internet> <ESSID> [password]    creates a mobile ap, which has two modes: local (no eth0 bridging), internet (eth0 bridging)
    aphidden <local|internet> <ESSID>         creates a hidden mobile ap, with or without internet access
             [password]


### PR DESCRIPTION
```bash
root@treehouses:~/cli# ./cli.sh bluetooth log dfs
Error: Too many arguments.

Usage: cli.sh bluetooth <on|off|pause|mac|id|button|log>

Switches between hotspot / regular bluetooth mode, or displays the bluetooth mac address

Example:
  cli.sh bluetooth
      off

  cli.sh bluetooth on
      This will start the bluetooth server, which lets the user control the raspberry pi using the mobile app.

  cli.sh bluetooth off
      This will stop the bluetooth server, and bring everything back to regular mode.
      This will also remove the bluetooth device id.

  cli.sh bluetooth pause
      Performs the same as 'cli.sh bluetooth off'
      The only difference is that this command will not remove the bluetooth device id.

  cli.sh bluetooth  mac
      This will display the bluetooth MAC address

  cli.sh bluetooth id
      This will display the network name along with the bluetooth id number

  cli.sh bluetooth button
      When the GPIO pin 18 is on the bluetooth will ne turned off
      Otherwise the bluetooth mode will be changed to hotspot

  cli.sh bluetooth id number
      This will display the bluetooth id number

  cli.sh bluetooth log
      This will follow and display the real time logs of bluetooth services
      (ctrl+c) to cancel

root@treehouses:~/cli# ./cli.sh bluetooth log
press (ctrl+c) to cancel
-- Logs begin at Wed 2020-04-15 18:17:01 EDT. --
Apr 15 18:18:11 treehouses systemd[1]: Starting Bluetooth service...
Apr 15 18:18:11 treehouses bluetoothd[630]: Bluetooth daemon 5.50
Apr 15 18:18:11 treehouses systemd[1]: Started Bluetooth service.
Apr 15 18:18:11 treehouses bluetoothd[630]: Starting SDP server
Apr 15 18:18:11 treehouses bluetoothd[630]: Bluetooth management interface 1.14 initialized
Apr 15 18:18:11 treehouses bluetoothd[630]: Sap driver initialization failed.
Apr 15 18:18:11 treehouses bluetoothd[630]: sap-server: Operation not permitted (1)
Apr 15 18:18:11 treehouses bluetoothd[630]: Endpoint registered: sender=:1.9 path=/org/bluez/hci0/A2DP/SBC/Source/1
Apr 15 18:18:11 treehouses bluetoothd[630]: Endpoint registered: sender=:1.9 path=/org/bluez/hci0/A2DP/SBC/Source/2
Apr 15 18:18:11 treehouses bluetoothd[630]: Failed to set privacy: Rejected (0x0b)
^C
root@treehouses:~/cli#

```