### PR TITLE
`treehouses bluetooth` checkargn (fixes #1080)

### DIFF
--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -2,7 +2,7 @@ function bluetooth {
   local status macfile macadd btidfile bid nname
   checkwrpi
   checkroot
-  checkargn $# 2
+  checkargn $# 1
   status=$1
 
   if [ -z "$status" ]; then

--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -64,6 +64,7 @@ function bluetooth {
     esac
 
    elif [ "$status" = "button" ]; then
+     checkargn $# 1
      button bluetooth
 
   else

--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -2,7 +2,7 @@ function bluetooth {
   local status macfile macadd btidfile bid nname
   checkwrpi
   checkroot
-  checkargn $# 1
+  checkargn $# 2
   status=$1
 
   if [ -z "$status" ]; then
@@ -13,6 +13,7 @@ function bluetooth {
     fi
 
   elif [ "$status" = "on" ]; then
+    checkargn $# 1
     cp "$TEMPLATES/bluetooth/hotspot" /etc/systemd/system/dbus-org.bluez.service
     enable_service rpibluetooth
     restart_service bluetooth
@@ -21,6 +22,7 @@ function bluetooth {
     echo "Success: the bluetooth service has been started."
 
   elif [ "$status" = "off" ] || [ "$status" = "pause" ]; then
+    checkargn $# 1
     cp "$TEMPLATES/bluetooth/default" /etc/systemd/system/dbus-org.bluez.service
     disable_service rpibluetooth
     stop_service rpibluetooth
@@ -33,6 +35,7 @@ function bluetooth {
     echo "Success: the bluetooth service has been switched to default, and the service has been stopped."
 
   elif [ "$status" = "mac" ]; then
+    checkargn $# 1
     macfile=/sys/kernel/debug/bluetooth/hci0/identity
     macadd=$(cat ${macfile})
     echo "${macadd:0:17}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.18.5",
+  "version": "1.18.14",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Fixes #1080

updated `treehouses bluetooth` to have `checkargn $# 1`