### PR TITLE
`treehouses bluetooth restart` (fixes #1093)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ bridge <ESSID> <hotspotESSID>             configures the rpi to bridge the wlan 
        [password] [hotspotPassword]
 config [update|add|delete|clear]          commands for interacting with config file
 container <none|docker|balena>            enables (and start) the desired container
-bluetooth [on|off|pause|button|mac|id]    switches bluetooth from regular to hotspot mode and shows id or MAC address
-          [status|log]
+bluetooth [on|off|pause|restart|button]   switches bluetooth from regular to hotspot mode and shows id or MAC address
+          [mac|id|status|log]
 ap <local|internet> <ESSID> [password]    creates a mobile ap, which has two modes: local (no eth0 bridging), internet (eth0 bridging)
 aphidden <local|internet> <ESSID>         creates a hidden mobile ap with or without internet access
          [password]

--- a/_treehouses
+++ b/_treehouses
@@ -25,6 +25,7 @@ treehouses bluetooth mac
 treehouses bluetooth off
 treehouses bluetooth on
 treehouses bluetooth pause
+treehouses bluetooth restart
 treehouses bluetooth status
 treehouses bootoption console
 treehouses bootoption console autologin

--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -83,14 +83,19 @@ function bluetooth {
      checkargn $# 1
      journalctl -u rpibluetooth -u bluetooth --no-pager
 
+   elif [ "$status" = "restart" ]; then
+     bluetooth off &>"$LOGFILE"
+     bluetooth on &>"$LOGFILE"
+     echo "Success: the bluetooth service has been restarted."
+
   else
-    echo "Error: only 'on', 'off', 'pause', 'mac', 'id', 'button', 'log', and 'status' options are supported";
+    echo "Error: only 'on', 'off', 'pause', 'restart', 'mac', 'id', 'button', 'log', and 'status' options are supported";
   fi
 }
 
 function bluetooth_help {
   echo
-  echo "Usage: $BASENAME bluetooth [on|off|pause|mac|id|button|status|log]"
+  echo "Usage: $BASENAME bluetooth [on|off|pause|restart|mac|id|button|status|log]"
   echo
   echo "Switches between hotspot / regular bluetooth mode, or displays the bluetooth mac address"
   echo
@@ -112,6 +117,9 @@ function bluetooth_help {
   echo "  $BASENAME bluetooth pause"
   echo "      Performs the same as '$BASENAME bluetooth off'"
   echo "      The only difference is that this command will not remove the bluetooth device id."
+  echo
+  echo "  $BASENAME bluetooth restart"
+  echo "      This will restart the bluetooth server using $BASENAME bleutooth 'off' and 'on'"
   echo
   echo "  $BASENAME bluetooth  mac"
   echo "      This will display the bluetooth MAC address"

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -26,8 +26,8 @@ Usage: treehouses
           [password] [hotspotPassword]
    config [update|add|delete|clear]          commands for interacting with config file
    container <none|docker|balena>            enables (and start) the desired container
-   bluetooth [on|off|pause|button|mac|id]    switches bluetooth from regular to hotspot mode and shows id or MAC address
-             [status|log]
+   bluetooth [on|off|pause|restart|button]   switches bluetooth from regular to hotspot mode and shows id or MAC address
+             [mac|id|status|log]
    ap <local|internet> <ESSID> [password]    creates a mobile ap, which has two modes: local (no eth0 bridging), internet (eth0 bridging)
    aphidden <local|internet> <ESSID>         creates a hidden mobile ap, with or without internet access
             [password]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.18.17",
+  "version": "1.18.20",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
```bash
root@treehouses:~/cli# ./cli.sh bluetooth restart
Success: the bluetooth service has been restarted.
root@treehouses:~/cli# ./cli.sh bluetooth log
-- Logs begin at Mon 2020-04-20 21:11:36 UTC, end at Wed 2020-04-22 23:49:37 UTC. --
Apr 20 21:11:40 treehouses systemd[1]: Started Bluetooth server.
Apr 20 21:11:41 treehouses python3[371]: Debug logs enabled
Apr 20 21:11:41 treehouses systemd[1]: Condition check resulted in Bluetooth service being skipped.
Apr 20 21:11:47 treehouses systemd[1]: Starting Bluetooth service...
Apr 20 21:11:47 treehouses bluetoothd[571]: Bluetooth daemon 5.50
Apr 20 21:11:47 treehouses systemd[1]: Started Bluetooth service.
Apr 20 21:11:47 treehouses bluetoothd[571]: Starting SDP server
Apr 20 21:11:47 treehouses bluetoothd[571]: Bluetooth management interface 1.14 initialized
Apr 20 21:11:47 treehouses bluetoothd[571]: Sap driver initialization failed.
Apr 20 21:11:47 treehouses bluetoothd[571]: sap-server: Operation not permitted (1)
Apr 20 21:11:47 treehouses bluetoothd[571]: Endpoint registered: sender=:1.9 path=/org/bluez/hci0/A2DP/SBC/Source/1
Apr 20 21:11:47 treehouses python3[371]: Setting device name: 'treehouses-8501'
Apr 20 21:11:47 treehouses bluetoothd[571]: Endpoint registered: sender=:1.9 path=/org/bluez/hci0/A2DP/SBC/Source/2
Apr 20 21:11:47 treehouses python3[371]: Serial Port service registered
Apr 20 21:11:47 treehouses bluetoothd[571]: Failed to set mode: Busy (0x0a)
Apr 20 21:11:47 treehouses python3[371]: Waiting for connections
Apr 20 21:11:47 treehouses bluetoothd[571]: Failed to set privacy: Rejected (0x0b)
Apr 20 21:11:47 treehouses python3[371]: Discoverable enabled
Apr 22 23:48:31 treehouses systemd[1]: bluetooth.service: Current command vanished from the unit file, execution of the command list won't be resumed.
Apr 22 23:48:31 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 22 23:48:31 treehouses systemd[1]: Stopping Bluetooth server...
Apr 22 23:48:31 treehouses python3[371]: Caught signal 15
Apr 22 23:48:31 treehouses python3[371]: Discoverable disabled
Apr 22 23:48:31 treehouses python3[371]: Stop waiting for connections ([Errno 4] Interrupted system call)
Apr 22 23:48:31 treehouses python3[371]: Server done
Apr 22 23:48:31 treehouses python3[371]: LE set advertise enable on hci0 returned status 12
Apr 22 23:48:31 treehouses python3[371]: Discoverable disabled
Apr 22 23:48:31 treehouses systemd[1]: rpibluetooth.service: Succeeded.
Apr 22 23:48:31 treehouses systemd[1]: Stopped Bluetooth server.
Apr 22 23:48:31 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 22 23:48:31 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 22 23:48:31 treehouses bluetoothd[571]: Endpoint unregistered: sender=:1.9 path=/org/bluez/hci0/A2DP/SBC/Source/1
Apr 22 23:48:31 treehouses bluetoothd[571]: Endpoint unregistered: sender=:1.9 path=/org/bluez/hci0/A2DP/SBC/Source/2
Apr 22 23:48:31 treehouses bluetoothd[571]: Terminating
Apr 22 23:48:31 treehouses systemd[1]: Stopping Bluetooth service...
Apr 22 23:48:31 treehouses bluetoothd[571]: Stopping SDP server
Apr 22 23:48:31 treehouses bluetoothd[571]: Exit
Apr 22 23:48:31 treehouses systemd[1]: bluetooth.service: Succeeded.
Apr 22 23:48:31 treehouses systemd[1]: Stopped Bluetooth service.
Apr 22 23:48:31 treehouses systemd[1]: Starting Bluetooth service...
Apr 22 23:48:32 treehouses bluetoothd[3419]: Bluetooth daemon 5.50
Apr 22 23:48:32 treehouses systemd[1]: Started Bluetooth service.
Apr 22 23:48:32 treehouses bluetoothd[3419]: Starting SDP server
Apr 22 23:48:32 treehouses bluetoothd[3419]: Bluetooth management interface 1.14 initialized
Apr 22 23:48:32 treehouses bluetoothd[3419]: Sap driver initialization failed.
Apr 22 23:48:32 treehouses bluetoothd[3419]: sap-server: Operation not permitted (1)
Apr 22 23:48:35 treehouses bluetoothd[3419]: Endpoint registered: sender=:1.33 path=/org/bluez/hci0/A2DP/SBC/Source/1
Apr 22 23:48:35 treehouses bluetoothd[3419]: Endpoint registered: sender=:1.33 path=/org/bluez/hci0/A2DP/SBC/Source/2
Apr 22 23:48:35 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 22 23:48:35 treehouses systemd[1]: bluetooth.service: Current command vanished from the unit file, execution of the command list won't be resumed.
Apr 22 23:48:35 treehouses bluetoothd[3419]: Endpoint unregistered: sender=:1.33 path=/org/bluez/hci0/A2DP/SBC/Source/1
Apr 22 23:48:35 treehouses bluetoothd[3419]: Endpoint unregistered: sender=:1.33 path=/org/bluez/hci0/A2DP/SBC/Source/2
Apr 22 23:48:35 treehouses bluetoothd[3419]: Terminating
Apr 22 23:48:35 treehouses systemd[1]: Stopping Bluetooth service...
Apr 22 23:48:35 treehouses bluetoothd[3419]: Stopping SDP server
Apr 22 23:48:35 treehouses bluetoothd[3419]: Exit
Apr 22 23:48:35 treehouses systemd[1]: bluetooth.service: Succeeded.
Apr 22 23:48:35 treehouses systemd[1]: Stopped Bluetooth service.
Apr 22 23:48:35 treehouses systemd[1]: Starting Bluetooth service...
Apr 22 23:48:36 treehouses bluetoothd[3568]: Bluetooth daemon 5.50
Apr 22 23:48:36 treehouses systemd[1]: Started Bluetooth service.
Apr 22 23:48:36 treehouses bluetoothd[3568]: Starting SDP server
Apr 22 23:48:36 treehouses bluetoothd[3568]: Bluetooth management interface 1.14 initialized
Apr 22 23:48:36 treehouses bluetoothd[3568]: Sap driver initialization failed.
Apr 22 23:48:36 treehouses bluetoothd[3568]: sap-server: Operation not permitted (1)
Apr 22 23:48:36 treehouses systemd[1]: Started Bluetooth server.
Apr 22 23:48:36 treehouses python3[3609]: Debug logs enabled
Apr 22 23:48:36 treehouses python3[3609]: Setting device name: 'treehouses-8065'
Apr 22 23:48:36 treehouses python3[3609]: Serial Port service registered
Apr 22 23:48:36 treehouses python3[3609]: Waiting for connections
Apr 22 23:48:36 treehouses python3[3609]: Discoverable enabled
Apr 22 23:49:32 treehouses systemd[1]: bluetooth.service: Current command vanished from the unit file, execution of the command list won't be resumed.
Apr 22 23:49:32 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 22 23:49:32 treehouses systemd[1]: Stopping Bluetooth server...
Apr 22 23:49:32 treehouses python3[3609]: Caught signal 15
Apr 22 23:49:32 treehouses python3[3609]: Discoverable disabled
Apr 22 23:49:32 treehouses python3[3609]: Stop waiting for connections ([Errno 4] Interrupted system call)
Apr 22 23:49:32 treehouses python3[3609]: Server done
Apr 22 23:49:32 treehouses python3[3609]: LE set advertise enable on hci0 returned status 12
Apr 22 23:49:32 treehouses python3[3609]: Discoverable disabled
Apr 22 23:49:32 treehouses systemd[1]: rpibluetooth.service: Succeeded.
Apr 22 23:49:32 treehouses systemd[1]: Stopped Bluetooth server.
Apr 22 23:49:32 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 22 23:49:32 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 22 23:49:32 treehouses bluetoothd[3568]: Terminating
Apr 22 23:49:32 treehouses systemd[1]: Stopping Bluetooth service...
Apr 22 23:49:32 treehouses bluetoothd[3568]: Stopping SDP server
Apr 22 23:49:32 treehouses bluetoothd[3568]: Exit
Apr 22 23:49:32 treehouses systemd[1]: bluetooth.service: Succeeded.
Apr 22 23:49:32 treehouses systemd[1]: Stopped Bluetooth service.
Apr 22 23:49:32 treehouses systemd[1]: Starting Bluetooth service...
Apr 22 23:49:32 treehouses bluetoothd[3868]: Bluetooth daemon 5.50
Apr 22 23:49:32 treehouses systemd[1]: Started Bluetooth service.
Apr 22 23:49:32 treehouses bluetoothd[3868]: Starting SDP server
Apr 22 23:49:32 treehouses bluetoothd[3868]: Bluetooth management interface 1.14 initialized
Apr 22 23:49:32 treehouses bluetoothd[3868]: Sap driver initialization failed.
Apr 22 23:49:32 treehouses bluetoothd[3868]: sap-server: Operation not permitted (1)
Apr 22 23:49:35 treehouses bluetoothd[3868]: Endpoint registered: sender=:1.38 path=/org/bluez/hci0/A2DP/SBC/Source/1
Apr 22 23:49:35 treehouses bluetoothd[3868]: Endpoint registered: sender=:1.38 path=/org/bluez/hci0/A2DP/SBC/Source/2
Apr 22 23:49:36 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 22 23:49:36 treehouses systemd[1]: bluetooth.service: Current command vanished from the unit file, execution of the command list won't be resumed.
Apr 22 23:49:36 treehouses bluetoothd[3868]: Endpoint unregistered: sender=:1.38 path=/org/bluez/hci0/A2DP/SBC/Source/1
Apr 22 23:49:36 treehouses bluetoothd[3868]: Endpoint unregistered: sender=:1.38 path=/org/bluez/hci0/A2DP/SBC/Source/2
Apr 22 23:49:36 treehouses systemd[1]: Stopping Bluetooth service...
Apr 22 23:49:36 treehouses bluetoothd[3868]: Terminating
Apr 22 23:49:36 treehouses bluetoothd[3868]: Stopping SDP server
Apr 22 23:49:36 treehouses bluetoothd[3868]: Exit
Apr 22 23:49:36 treehouses systemd[1]: bluetooth.service: Succeeded.
Apr 22 23:49:36 treehouses systemd[1]: Stopped Bluetooth service.
Apr 22 23:49:36 treehouses systemd[1]: Starting Bluetooth service...
Apr 22 23:49:36 treehouses bluetoothd[4013]: Bluetooth daemon 5.50
Apr 22 23:49:36 treehouses systemd[1]: Started Bluetooth service.
Apr 22 23:49:36 treehouses bluetoothd[4013]: Starting SDP server
Apr 22 23:49:36 treehouses bluetoothd[4013]: Bluetooth management interface 1.14 initialized
Apr 22 23:49:36 treehouses bluetoothd[4013]: Sap driver initialization failed.
Apr 22 23:49:36 treehouses bluetoothd[4013]: sap-server: Operation not permitted (1)
Apr 22 23:49:36 treehouses systemd[1]: Started Bluetooth server.
Apr 22 23:49:36 treehouses python3[4059]: Debug logs enabled
Apr 22 23:49:36 treehouses python3[4059]: Setting device name: 'treehouses-5346'
Apr 22 23:49:36 treehouses python3[4059]: Serial Port service registered
Apr 22 23:49:36 treehouses python3[4059]: Waiting for connections
Apr 22 23:49:37 treehouses python3[4059]: Discoverable enabled

```

no checkargn because that is a different issue already created