### PR TITLE
`treehouses upgrade bluetooth`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ssh <on|off>                              enables or disables the ssh service
 vnc [on|off|info]                         enables or disables the vnc server service
 default                                   sets a raspbian back to default configuration
 wificountry <country>                     sets the wifi country
-upgrade [tag] [--check]                   upgrades cli.sh package using npm
+upgrade [tag|bluetooth] [--check]         upgrades cli.sh package using npm
 sshtunnel <add|remove|list|check|notice>  helps adding an sshtunnel
           <key|portinterval> [user@host]
 led [green|red] [mode]                    sets the led mode

--- a/_treehouses
+++ b/_treehouses
@@ -583,6 +583,7 @@ treehouses tor stop
 treehouses upgrade
 treehouses upgrade --check
 treehouses upgrade -f
+treehouses upgrade bluetooth
 treehouses usb off
 treehouses usb on
 treehouses verbose

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -38,7 +38,7 @@ Usage: treehouses
    vnc [on|off|info]                         enables or disables the vnc server service
    default                                   sets a raspbian back to default configuration
    wificountry <country>                     sets the wifi country
-   upgrade [tag] [--check]                   upgrades treehouses package using npm
+   upgrade [tag|bluetooth] [--check]         upgrades treehouses package using npm
    sshtunnel <add|remove|list|check|notice>  helps adding an sshtunnel
              <key|portinterval> [user@host]
    led [green|red] [mode]                    sets the led mode

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -26,6 +26,14 @@ function upgrade {
       exit
     fi
     echo "true $last_version"
+  elif [ "$tag" == "bluetooth" ];
+    if [ "$(internet)" == "true" ]; then
+      curl -s "https://raw.githubusercontent.com/treehouses/control/master/server.py" -o /usr/local/bin/bluetooth-server.py
+      bluetooth restart
+      echo "Successfully updated and restarted bluetooth server"
+    else
+      echo "Error: internet not available"
+    fi
   else
     npm install -g "@treehouses/cli@${tag}"
   fi
@@ -33,7 +41,7 @@ function upgrade {
 
 function upgrade_help {
   echo
-  echo "Usage: $BASENAME upgrade [tag] [--check]"
+  echo "Usage: $BASENAME upgrade [tag|bluetooth] [--check]"
   echo
   echo "Upgrades $BASENAME package using npm"
   echo
@@ -47,5 +55,8 @@ function upgrade_help {
   echo
   echo " $BASENAME upgrade --check"
   echo "    checks if there is a new version of the package, outputs false if there isnt, outputs true + version if there is"
+  echo
+  echo " $BASENAME upgrade bluetooth"
+  echo "    This will upgrade the bluetooth server to the latest if internet is available and restart bluetooth"
   echo
 }

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -31,6 +31,7 @@ function upgrade {
     checkroot
     checkwrpi
     checkinternet
+    cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +"%Y%m%d%H%m%S")"
     curl -s "https://raw.githubusercontent.com/treehouses/control/master/server.py" -o /usr/local/bin/bluetooth-server.py
     bluetooth restart &>"$LOGFILE"
     echo "Successfully updated and restarted bluetooth server"

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -26,10 +26,13 @@ function upgrade {
       exit
     fi
     echo "true $last_version"
-  elif [ "$tag" == "bluetooth" ];
+  elif [ "$tag" == "bluetooth" ]; then
+    checkargn $# 1
+    checkwrpi
+    checkroot
     if [ "$(internet)" == "true" ]; then
       curl -s "https://raw.githubusercontent.com/treehouses/control/master/server.py" -o /usr/local/bin/bluetooth-server.py
-      bluetooth restart
+      bluetooth restart &>"$LOGFILE"
       echo "Successfully updated and restarted bluetooth server"
     else
       echo "Error: internet not available"

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -31,7 +31,7 @@ function upgrade {
     checkroot
     checkwrpi
     checkinternet
-    cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +"%Y%m%d%H%m%S")"
+    cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     curl -s "https://raw.githubusercontent.com/treehouses/control/master/server.py" -o /usr/local/bin/bluetooth-server.py
     bluetooth restart &>"$LOGFILE"
     echo "Successfully updated and restarted bluetooth server"

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -28,15 +28,12 @@ function upgrade {
     echo "true $last_version"
   elif [ "$tag" == "bluetooth" ]; then
     checkargn $# 1
-    checkwrpi
     checkroot
-    if [ "$(internet)" == "true" ]; then
-      curl -s "https://raw.githubusercontent.com/treehouses/control/master/server.py" -o /usr/local/bin/bluetooth-server.py
-      bluetooth restart &>"$LOGFILE"
-      echo "Successfully updated and restarted bluetooth server"
-    else
-      echo "Error: internet not available"
-    fi
+    checkwrpi
+    checkinternet
+    curl -s "https://raw.githubusercontent.com/treehouses/control/master/server.py" -o /usr/local/bin/bluetooth-server.py
+    bluetooth restart &>"$LOGFILE"
+    echo "Successfully updated and restarted bluetooth server"
   else
     npm install -g "@treehouses/cli@${tag}"
   fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.19.0",
+  "version": "1.19.7",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",

--- a/tests/upgrade.bats
+++ b/tests/upgrade.bats
@@ -11,12 +11,12 @@ load test-helper
   assert_success
 }
 
-@test "$clinom upgrade -f" {
-  run "${clicmd}" upgrade -f
+@test "$clinom upgrade" {
+  run "${clicmd}" upgrade
   assert_success
 }
 
-@test "$clinom upgrade" {
-  run "${clicmd}" upgrade
+@test "$clinom upgrade bluetooth" {
+  run "${clicmd}" upgrade bluetooth
   assert_success
 }


### PR DESCRIPTION
```bash
root@treehouses:~/cli# ./cli.sh upgrade bluetooth
Successfully updated and restarted bluetooth server
root@treehouses:~/cli# rm -rf /usr/local/bin/bluetooth-server.py
root@treehouses:~/cli# ./cli.sh upgrade bluetooth         Successfully updated and restarted bluetooth server
root@treehouses:~/cli# ls /usr/local/bin
bluetooth-server.py  hub-ctrl     sl         youtube-dl
do_autorun           jsonschema   terraform
docker-compose       __pycache__  wsdump.py
root@treehouses:~/cli# ./cli.sh upgrade bluetooth dfsd
Error: Too many arguments.

Usage: cli.sh upgrade [tag|bluetooth] [--check]

Upgrades cli.sh package using npm

Example:
 cli.sh upgrade
    This will upgrade the cli.sh package using npm and will try to install the latest version of cli.sh running on your system
    If the latest version if installed it will not try to reinstall it

 cli.sh upgrade tag
    This will upgrade the cli.sh package to the version with the specified tag

 cli.sh upgrade --check
    checks if there is a new version of the package, outputs false if there isnt, outputs true + version if there is

 cli.sh upgrade bluetooth
    This will upgrade the bluetooth server to the latest if internet is available and restart bluetooth

root@treehouses:~/cli#

```