### PR TITLE
`treehouses bluetooth log follow` (fixes #1120)

### DIFF
--- a/_treehouses
+++ b/_treehouses
@@ -21,6 +21,7 @@ treehouses bluetooth button
 treehouses bluetooth id
 treehouses bluetooth id number
 treehouses bluetooth log
+treehouses bluetooth log follow
 treehouses bluetooth mac
 treehouses bluetooth off
 treehouses bluetooth on

--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -88,6 +88,7 @@ function bluetooth {
        journalctl -u rpibluetooth -u bluetooth -f
      else
        echo "Argument not valid; leave blank or use \"follow\""
+       exit 1
      fi
 
    elif [ "$status" = "restart" ]; then

--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -80,8 +80,15 @@ function bluetooth {
      button bluetooth
 
    elif [ "$status" = "log" ]; then
-     checkargn $# 1
-     journalctl -u rpibluetooth -u bluetooth --no-pager
+     if [ "$2" = "" ]; then
+       checkargn $# 1
+       journalctl -u rpibluetooth -u bluetooth --no-pager
+     elif [ "$2" = "follow" ]; then
+       echo "press (ctrl + c) to exit"
+       journalctl -u rpibluetooth -u bluetooth -f
+     else
+       echo "Argument not valid; leave blank or use \"follow\""
+     fi
 
    elif [ "$status" = "restart" ]; then
      bluetooth off &>"$LOGFILE"
@@ -136,5 +143,9 @@ function bluetooth_help {
   echo
   echo "  $BASENAME bluetooth log"
   echo "      This will display the logs of bluetooth services"
+  echo
+  echo "  $BASENAME bluetooth log follow"
+  echo "      This will display the logs as they come in live of the bluetooth services"
+  echo "      press (ctrl + c) to exit"
   echo
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.19.3",
+  "version": "1.19.6",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
```bash
root@treehouses:~/cli# ./cli.sh bluetooth log sdfs
Argument not valid; leave blank or use "follow"
root@treehouses:~/cli# ./cli.sh bluetooth log follow sdfs
Error: Too many arguments.

Usage: cli.sh bluetooth [on|off|pause|restart|mac|id|button|status|log]

Switches between hotspot / regular bluetooth mode, or displays the bluetooth mac address

Example:
  cli.sh bluetooth
      on

  cli.sh bluetooth status
      bluetooth service status: on
      rpibluetooth service status: on

  cli.sh bluetooth on
      This will start the bluetooth server, which lets the user control the raspberry pi using the mobile app.

  cli.sh bluetooth off
      This will stop the bluetooth server, and bring everything back to regular mode.
      This will also remove the bluetooth device id.

  cli.sh bluetooth pause
      Performs the same as 'cli.sh bluetooth off'
      The only difference is that this command will not remove the bluetooth device id.

  cli.sh bluetooth restart
      This will restart the bluetooth server using cli.sh bleutooth 'off' and 'on'

  cli.sh bluetooth  mac
      This will display the bluetooth MAC address

  cli.sh bluetooth id
      Th
```