### PR TITLE
`treehouses bluetooth log off/on` (fixes #1129)

### DIFF
--- a/_treehouses
+++ b/_treehouses
@@ -22,6 +22,8 @@ treehouses bluetooth id
 treehouses bluetooth id number
 treehouses bluetooth log
 treehouses bluetooth log follow
+treehouses bluetooth log off
+treehouses bluetooth log on
 treehouses bluetooth mac
 treehouses bluetooth off
 treehouses bluetooth on

--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -86,6 +86,12 @@ function bluetooth {
      elif [ "$2" = "follow" ]; then
        echo "press (ctrl + c) to exit"
        journalctl -u rpibluetooth -u bluetooth -f
+     elif [ "$2" = "on" ]; then
+       sed -i 's/logging.ERROR/logging.DEBUG/g' /usr/local/bin/bluetooth-server.py
+       bluetooth restart &>"$LOGFILE"
+     elif [ "$2" = "off" ]; then
+       sed -i 's/logging.DEBUG/logging.ERROR/g' /usr/local/bin/bluetooth-server.py
+       bluetooth restart &>"$LOGFILE"
      else
        echo "Argument not valid; leave blank or use \"follow\""
        exit 1
@@ -148,5 +154,11 @@ function bluetooth_help {
   echo "  $BASENAME bluetooth log follow"
   echo "      This will display the logs as they come in live of the bluetooth services"
   echo "      press (ctrl + c) to exit"
+  echo
+  echo "  $BASENAME bluetooth log off"
+  echo "      This will turn off the log for the bluetooth and restart the services"
+  echo
+  echo "  $BASENAME bluetooth log on"
+  echo "      This will turn on the log for the bluetooth and restart the services"
   echo
 }


### PR DESCRIPTION
- Turns the log off and on for the bluetooth server
- `treehouses bluetooth log` or `treehouses bluetooth log follow` to test

```bash
root@treehouses:~/cli# ls
cli.sh   modules       README.md  templates  _treehouses
LICENSE  package.json  services   tests      Vagrantfile
root@treehouses:~/cli# ./cli.sh bluetooth log off sdas
Error: Too many arguments.

Usage: cli.sh bluetooth [on|off|pause|restart|mac|id|button|status|log]

Switches between hotspot / regular bluetooth mode, or displays the bluetooth mac address

Example:
  cli.sh bluetooth
      on

  cli.sh bluetooth status
      bluetooth service status: on
      rpibluetooth service status: on

  cli.sh bluetooth on
      This will start the bluetooth server, which lets the user control the raspberry pi using the mobile app.

  cli.sh bluetooth off
      This will stop the bluetooth server, and bring everything back to regular mode.
      This will also remove the bluetooth device id.

  cli.sh bluetooth pause
      Performs the same as 'cli.sh bluetooth off'
      The only difference is that this command will not remove the bluetooth device id.

  cli.sh bluetooth restart
      This will restart the bluetooth server using cli.sh bleutooth 'off' and 'on'

  cli.sh bluetooth  mac
      This will display the bluetooth MAC address

  cli.sh bluetooth id
      This will display the network name along with the bluetooth id number

  cli.sh bluetooth button
      When the GPIO pin 18 is on the bluetooth will ne turned off
      Otherwise the bluetooth mode will be changed to hotspot

  cli.sh bluetooth id number
      This will display the bluetooth id number

  cli.sh bluetooth log
      This will display the logs of bluetooth services

  cli.sh bluetooth log follow
      This will display the logs as they come in live of the bluetooth services
      press (ctrl + c) to exit

  cli.sh bluetooth log off
      This will turn off the log for the bluetooth and restart the services

  cli.sh bluetooth log on
      This will turn on the log for the bluetooth and restart the services

root@treehouses:~/cli# ./cli.sh bluetooth log off
root@treehouses:~/cli# ./cli.sh bluetooth log on

```
```bash
root@treehouses:~/cli# treehouses bluetooth log follow
press (ctrl + c) to exit
-- Logs begin at Tue 2020-04-28 01:17:01 UTC. --
Apr 28 20:55:04 treehouses python3[4371]: Main thread waiting for connections
Apr 28 20:55:04 treehouses python3[4371]: 7D:B7 R treehouses remote version 2418
Apr 28 20:55:05 treehouses python3[4371]: 7D:B7 S - version: true
Apr 28 20:55:06 treehouses python3[4371]: 7D:B7 R treehouses remote check
Apr 28 20:55:06 treehouses python3[4371]: 7D:B7 S - dc:a6:32:54:ae:f7 release-128 1.19.8 RPI4B
Apr 28 20:55:07 treehouses python3[4371]: 7D:B7 R treehouses internet
Apr 28 20:55:07 treehouses python3[4371]: 7D:B7 S - true
Apr 28 20:55:08 treehouses python3[4371]: 7D:B7 R treehouses upgrade --check
Apr 28 20:55:11 treehouses python3[4371]: 7D:B7 S - false
Apr 28 20:55:12 treehouses python3[4371]: Disconnected from 64:BC:0C:E2:7D:B7
Apr 28 21:13:15 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 28 21:13:15 treehouses systemd[1]: bluetooth.service: Current command vanished from the unit file, execution of the command list won't be resumed.
Apr 28 21:13:15 treehouses systemd[1]: Stopping Bluetooth server...
Apr 28 21:13:15 treehouses systemd[1]: rpibluetooth.service: Main process exited, code=killed, status=15/TERM
Apr 28 21:13:15 treehouses systemd[1]: rpibluetooth.service: Succeeded.
Apr 28 21:13:15 treehouses systemd[1]: Stopped Bluetooth server.
Apr 28 21:13:15 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 28 21:13:15 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 28 21:13:15 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 28 21:13:15 treehouses bluetoothd[603]: Endpoint unregistered: sender=:1.9 path=/org/bluez/hci0/A2DP/SBC/Source/1
Apr 28 21:13:15 treehouses bluetoothd[603]: Endpoint unregistered: sender=:1.9 path=/org/bluez/hci0/A2DP/SBC/Source/2
Apr 28 21:13:15 treehouses bluetoothd[603]: Terminating
Apr 28 21:13:15 treehouses systemd[1]: Stopping Bluetooth service...
Apr 28 21:13:15 treehouses bluetoothd[603]: Stopping SDP server
Apr 28 21:13:15 treehouses bluetoothd[603]: Exit
Apr 28 21:13:15 treehouses systemd[1]: bluetooth.service: Succeeded.
Apr 28 21:13:15 treehouses systemd[1]: Stopped Bluetooth service.
Apr 28 21:13:15 treehouses systemd[1]: Starting Bluetooth service...
Apr 28 21:13:15 treehouses bluetoothd[6795]: Bluetooth daemon 5.50
Apr 28 21:13:15 treehouses systemd[1]: Started Bluetooth service.
Apr 28 21:13:15 treehouses bluetoothd[6795]: Starting SDP server
Apr 28 21:13:15 treehouses bluetoothd[6795]: Bluetooth management interface 1.14 initialized
Apr 28 21:13:15 treehouses bluetoothd[6795]: Sap driver initialization failed.
Apr 28 21:13:15 treehouses bluetoothd[6795]: sap-server: Operation not permitted (1)
Apr 28 21:13:18 treehouses bluetoothd[6795]: Endpoint registered: sender=:1.55 path=/org/bluez/hci0/A2DP/SBC/Source/1
Apr 28 21:13:18 treehouses bluetoothd[6795]: Endpoint registered: sender=:1.55 path=/org/bluez/hci0/A2DP/SBC/Source/2
Apr 28 21:13:18 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 28 21:13:19 treehouses systemd[1]: bluetooth.service: Current command vanished from the unit file, execution of the command list won't be resumed.
Apr 28 21:13:19 treehouses bluetoothd[6795]: Endpoint unregistered: sender=:1.55 path=/org/bluez/hci0/A2DP/SBC/Source/1
Apr 28 21:13:19 treehouses bluetoothd[6795]: Endpoint unregistered: sender=:1.55 path=/org/bluez/hci0/A2DP/SBC/Source/2
Apr 28 21:13:19 treehouses bluetoothd[6795]: Terminating
Apr 28 21:13:19 treehouses systemd[1]: Stopping Bluetooth service...
Apr 28 21:13:19 treehouses bluetoothd[6795]: Stopping SDP server
Apr 28 21:13:19 treehouses bluetoothd[6795]: Exit
Apr 28 21:13:19 treehouses systemd[1]: bluetooth.service: Succeeded.
Apr 28 21:13:19 treehouses systemd[1]: Stopped Bluetooth service.
Apr 28 21:13:19 treehouses systemd[1]: Starting Bluetooth service...
Apr 28 21:13:19 treehouses bluetoothd[6849]: Bluetooth daemon 5.50
Apr 28 21:13:19 treehouses systemd[1]: Started Bluetooth service.
Apr 28 21:13:19 treehouses bluetoothd[6849]: Starting SDP server
Apr 28 21:13:19 treehouses bluetoothd[6849]: Bluetooth management interface 1.14 initialized
Apr 28 21:13:19 treehouses bluetoothd[6849]: Sap driver initialization failed.
Apr 28 21:13:19 treehouses bluetoothd[6849]: sap-server: Operation not permitted (1)
Apr 28 21:13:19 treehouses systemd[1]: Started Bluetooth server.
Apr 28 21:20:09 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 28 21:20:09 treehouses systemd[1]: bluetooth.service: Current command vanished from the unit file, execution of the command list won't be resumed.
Apr 28 21:20:09 treehouses systemd[1]: Stopping Bluetooth server...
Apr 28 21:20:09 treehouses systemd[1]: rpibluetooth.service: Main process exited, code=killed, status=15/TERM
Apr 28 21:20:09 treehouses systemd[1]: rpibluetooth.service: Succeeded.
Apr 28 21:20:09 treehouses systemd[1]: Stopped Bluetooth server.
Apr 28 21:20:09 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 28 21:20:09 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 28 21:20:09 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 28 21:20:09 treehouses bluetoothd[6849]: Terminating
Apr 28 21:20:09 treehouses systemd[1]: Stopping Bluetooth service...
Apr 28 21:20:09 treehouses bluetoothd[6849]: Stopping SDP server
Apr 28 21:20:09 treehouses bluetoothd[6849]: Exit
Apr 28 21:20:09 treehouses systemd[1]: bluetooth.service: Succeeded.
Apr 28 21:20:09 treehouses systemd[1]: Stopped Bluetooth service.
Apr 28 21:20:09 treehouses systemd[1]: Starting Bluetooth service...
Apr 28 21:20:09 treehouses bluetoothd[7789]: Bluetooth daemon 5.50
Apr 28 21:20:09 treehouses systemd[1]: Started Bluetooth service.
Apr 28 21:20:09 treehouses bluetoothd[7789]: Starting SDP server
Apr 28 21:20:09 treehouses bluetoothd[7789]: Bluetooth management interface 1.14 initialized
Apr 28 21:20:09 treehouses bluetoothd[7789]: Sap driver initialization failed.
Apr 28 21:20:09 treehouses bluetoothd[7789]: sap-server: Operation not permitted (1)
Apr 28 21:20:12 treehouses bluetoothd[7789]: Endpoint registered: sender=:1.60 path=/org/bluez/hci0/A2DP/SBC/Source/1
Apr 28 21:20:12 treehouses bluetoothd[7789]: Endpoint registered: sender=:1.60 path=/org/bluez/hci0/A2DP/SBC/Source/2
Apr 28 21:20:13 treehouses systemd[1]: rpibluetooth.service: Dependency After=rpibluetooth.service dropped
Apr 28 21:20:13 treehouses systemd[1]: bluetooth.service: Current command vanished from the unit file, execution of the command list won't be resumed.
Apr 28 21:20:13 treehouses bluetoothd[7789]: Endpoint unregistered: sender=:1.60 path=/org/bluez/hci0/A2DP/SBC/Source/1
Apr 28 21:20:13 treehouses bluetoothd[7789]: Endpoint unregistered: sender=:1.60 path=/org/bluez/hci0/A2DP/SBC/Source/2
Apr 28 21:20:13 treehouses bluetoothd[7789]: Terminating
Apr 28 21:20:13 treehouses systemd[1]: Stopping Bluetooth service...
Apr 28 21:20:13 treehouses bluetoothd[7789]: Stopping SDP server
Apr 28 21:20:13 treehouses bluetoothd[7789]: Exit
Apr 28 21:20:13 treehouses systemd[1]: bluetooth.service: Succeeded.
Apr 28 21:20:13 treehouses systemd[1]: Stopped Bluetooth service.
Apr 28 21:20:13 treehouses systemd[1]: Starting Bluetooth service...
Apr 28 21:20:13 treehouses bluetoothd[7838]: Bluetooth daemon 5.50
Apr 28 21:20:13 treehouses systemd[1]: Started Bluetooth service.
Apr 28 21:20:13 treehouses bluetoothd[7838]: Starting SDP server
Apr 28 21:20:13 treehouses bluetoothd[7838]: Bluetooth management interface 1.14 initialized
Apr 28 21:20:13 treehouses bluetoothd[7838]: Sap driver initialization failed.
Apr 28 21:20:13 treehouses bluetoothd[7838]: sap-server: Operation not permitted (1)
Apr 28 21:20:13 treehouses systemd[1]: Started Bluetooth server.
Apr 28 21:20:13 treehouses python3[7843]: Debug logs enabled
Apr 28 21:20:13 treehouses python3[7843]: Setting device name: 'treehouses-6510'
Apr 28 21:20:13 treehouses python3[7843]: Discoverable enabled
Apr 28 21:20:13 treehouses python3[7843]: Listening on port 0
Apr 28 21:20:13 treehouses python3[7843]: Main thread waiting for connections
Apr 28 21:20:38 treehouses python3[7843]: Accepted connection from 64:BC:0C:E2:7D:B7
Apr 28 21:20:38 treehouses python3[7843]: Main thread waiting for connections
Apr 28 21:20:38 treehouses python3[7843]: 7D:B7 R treehouses remote version 2418
Apr 28 21:20:39 treehouses python3[7843]: 7D:B7 S - version: true
Apr 28 21:20:39 treehouses python3[7843]: 7D:B7 R treehouses remote check
Apr 28 21:20:39 treehouses python3[7843]: 7D:B7 S - dc:a6:32:54:ae:f7 release-128 1.19.8 RPI4B
Apr 28 21:20:39 treehouses python3[7843]: 7D:B7 R treehouses internet
Apr 28 21:20:40 treehouses python3[7843]: 7D:B7 S - true
Apr 28 21:20:40 treehouses python3[7843]: 7D:B7 R treehouses upgrade --check
Apr 28 21:20:44 treehouses python3[7843]: 7D:B7 S - false
Apr 28 21:20:44 treehouses python3[7843]: Disconnected from 64:BC:0C:E2:7D:B7

```