### PR TITLE
add `.gitattributes` to force unix line endings (fixes #1126)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.19.8",
+  "version": "1.19.13",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Doesn't seem to fix the problem. I think the problem lies with the other repository. 

```bash

Gaming@DESKTOP-RIQ2OSF MINGW64 ~/Desktop/cli (gitattrib)
$ vagrant up
Bringing machine 'cli' up with 'virtualbox' provider...
==> cli: Importing base box 'treehouses/buster64'...
==> cli: Matching MAC address for NAT networking...
==> cli: Checking if box 'treehouses/buster64' version '0.12.5' is up to date...
==> cli: Setting the name of the VM: cli
==> cli: Clearing any previously set network interfaces...
==> cli: Preparing network interfaces based on configuration...
    cli: Adapter 1: nat
==> cli: Forwarding ports...
    cli: 22 (guest) => 2222 (host) (adapter 1)
==> cli: Running 'pre-boot' VM customizations...
==> cli: Booting VM...
==> cli: Waiting for machine to boot. This may take a few minutes...
    cli: SSH address: 127.0.0.1:2222
    cli: SSH username: vagrant
    cli: SSH auth method: private key
==> cli: Machine booted and ready!
==> cli: Checking for guest additions in VM...
    cli: The guest additions on this VM do not match the installed version of
    cli: VirtualBox! In most cases this is fine, but in rare cases it can
    cli: prevent things such as shared folders from working properly. If you see
    cli: shared folder errors, please make sure the guest additions within the
    cli: virtual machine match the version of VirtualBox you have installed on
    cli: your host and reload your VM.
    cli:
    cli: Guest Additions Version: 6.0.12
    cli: VirtualBox Version: 6.1
==> cli: Setting hostname...
==> cli: Mounting shared folders...
    cli: /vagrant => C:/Users/Gaming/Desktop/cli
==> cli: Running provisioner: shell...
    cli: Running: inline script
==> cli: Running provisioner: shell...
    cli: Running: inline script

Gaming@DESKTOP-RIQ2OSF MINGW64 ~/Desktop/cli (gitattrib)
$ vagrant ssh
Linux cli 4.19.0-6-amd64 #1 SMP Debian 4.19.67-2+deb10u2 (2019-11-11) x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
vagrant@cli:~$ ls
add-cors-to-couchdb  cli  install.yml  package-lock.json  planet.yml  terraform_0.12.10_linux_amd64.zip  volumes.yml
vagrant@cli:~$ cd cli
vagrant@cli:~/cli$ ./cli.sh version
-bash: ./cli.sh: /bin/bash^M: bad interpreter: No such file or directory
vagrant@cli:~/cli$ ls
cli.sh  LICENSE  modules  package.json  README.md  services  templates  tests  _treehouses  Vagrantfile
vagrant@cli:~/cli$ ls -lha
total 142K
drwxrwxrwx  1 vagrant vagrant 4.0K Apr 28 21:55 .
drwxr-xr-x 20 root    root    4.0K Dec 26 10:00 ..
-rwxrwxrwx  1 vagrant vagrant 1.1K Apr 28 21:36 cli.sh
-rwxrwxrwx  1 vagrant vagrant  308 Apr 28 21:36 .codeclimate.yml
drwxrwxrwx  1 vagrant vagrant 4.0K Apr 28 21:37 .git
-rwxrwxrwx  1 vagrant vagrant   14 Apr 28 21:37 .gitattributes
-rwxrwxrwx  1 vagrant vagrant   36 Apr 28 21:36 .gitignore
-rwxrwxrwx  1 vagrant vagrant  35K Apr 28 21:36 LICENSE
drwxrwxrwx  1 vagrant vagrant  16K Apr 28 21:36 modules
-rwxrwxrwx  1 vagrant vagrant 1.6K Apr 28 21:36 package.json
-rwxrwxrwx  1 vagrant vagrant 9.5K Apr 28 21:36 README.md
drwxrwxrwx  1 vagrant vagrant 4.0K Apr 28 21:36 services
drwxrwxrwx  1 vagrant vagrant 4.0K Apr 28 21:36 templates
drwxrwxrwx  1 vagrant vagrant  28K Apr 28 21:36 tests
-rwxrwxrwx  1 vagrant vagrant 1.1K Apr 28 21:36 .travis.yml
-rwxrwxrwx  1 vagrant vagrant 9.8K Apr 28 21:36 _treehouses
drwxrwxrwx  1 vagrant vagrant    0 Apr 28 21:55 .vagrant
-rwxrwxrwx  1 vagrant vagrant 1.3K Apr 28 21:55 Vagrantfile
vagrant@cli:~/cli$ nano .gitattributes
vagrant@cli:~/cli$

```