### PR TITLE
`treehouses tor notice` error message (fixes #936)

### DIFF
--- a/modules/tor.sh
+++ b/modules/tor.sh
@@ -158,7 +158,7 @@ function tor {
       fi
       echo "Status: $status"
     else
-      echo "Error: only 'on' and 'off' options are supported."
+      echo "Error: only 'on', 'off', 'now', 'add', 'delete', and 'list' options are supported."
     fi
   elif [ "$1" = "status" ]; then
     systemctl is-active tor

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.19.8",
+  "version": "1.19.14",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
```bash
root@treehouses:~/cli# ./cli.sh tor notice nowq
Error: only 'on', 'off', 'now', 'add', 'delete', and 'list' options are supported.
```