### PR TITLE
`treehouses detectrpi full` error message (fixes #951)

### DIFF
--- a/modules/detectrpi.sh
+++ b/modules/detectrpi.sh
@@ -74,7 +74,7 @@ function detectrpi {
       rpimodel=$(tr -d '\0' </sys/firmware/devicetree/base/model)
       echo "$rpimodel"
     else
-      log_and_exit1 "Error: only 'detectrpi', and 'detectrpi model' commands supported"
+      log_and_exit1 "Error: only 'detectrpi', 'detectrpi model', and 'detectrpi full' commands supported"
     fi
   else
     if grep -q -s "Raspberry Pi" "/sys/firmware/devicetree/base/model"; then
@@ -98,5 +98,8 @@ function detectrpi_help {
   echo
   echo "  $BASENAME detectrpi model"
   echo "      Prints the model number of the RPi"
+  echo
+  echo "  $BASENAME detectrpi full"
+  echo "      Prints the full model of the RPi"
   echo
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.19.8",
+  "version": "1.19.16",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
```bash
root@treehouses:~/cli# ./cli.sh detectrpi full
Raspberry Pi 4 Model B Rev 1.2
root@treehouses:~/cli# ./cli.sh detectrpi fullq
Error: only 'detectrpi', 'detectrpi model', and 'detectrpi full' commands supported
root@treehouses:~/cli# ./cli.sh help detectrpi

Usage: cli.sh detectrpi

Detects the hardware version

Example:
  cli.sh detectrpi
      Prints the Raspberry Pi name

  cli.sh detectrpi model
      Prints the model number of the RPi

  cli.sh detectrpi full
      Prints the full model of the RPi

root@treehouses:~/cli#


```