### PR TITLE
`treehouses upgrade bluetooth <branch>` (fixes #1127)

### DIFF
--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -73,5 +73,6 @@ function upgrade_help {
   echo
   echo " $BASENAME upgrade bluetooth branchname"
   echo "    This will do the same as the above but use the 'branchname' branch on the bluetooth server repository"
+  echo "    https://github.com/treehouses/control"
   echo
 }

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -1,5 +1,5 @@
 function upgrade {
-  local tag last_version
+  local tag last_version branch existed_in_remote
   checkargn $# 2
   tag=$1
   # `--check` to be deprecated at some point
@@ -29,12 +29,21 @@ function upgrade {
     fi
     echo "true $last_version"
   elif [ "$tag" == "bluetooth" ]; then
-    checkargn $# 1
+    checkargn $# 2
     checkroot
     checkwrpi
     checkinternet
+    if [ "$2" = "" ]; then
+      branch="master"
+    else
+      branch="$2"
+      existed_in_remote=$(git ls-remote -h https://github.com/treehouses/control.git ${branch})
+      if [[ -z ${existed_in_remote} ]]; then
+        log_and_exit1 "Error: branch specified not found on bluetooth server repository"
+      fi
+    fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    curl -s "https://raw.githubusercontent.com/treehouses/control/master/server.py" -o /usr/local/bin/bluetooth-server.py
+    curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
     bluetooth restart &>"$LOGFILE"
     echo "Successfully updated and restarted bluetooth server"
   else
@@ -61,5 +70,8 @@ function upgrade_help {
   echo
   echo " $BASENAME upgrade bluetooth"
   echo "    This will upgrade the bluetooth server to the latest if internet is available and restart bluetooth"
+  echo
+  echo " $BASENAME upgrade bluetooth branchname"
+  echo "    This will do the same as the above but use the 'branchname' branch on the bluetooth server repository"
   echo
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.19.8",
+  "version": "1.19.9",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
```bash
root@treehouses:~/cli# ./cli.sh upgrade bluetooth
Successfully updated and restarted bluetooth server
root@treehouses:~/cli# ./cli.sh upgrade bluetooth sdfdaf
Error: branch specified not found on bluetooth server repository
root@treehouses:~/cli# ./cli.sh upgrade bluetooth multioverhaul
Successfully updated and restarted bluetooth server
root@treehouses:~/cli# cat /usr/local/bin/bluetooth-server.py
#!/usr/bin/python3
import logging
import logging.handlers
import os
import signal
import subprocess
import sys
import threading
import socket
import string
import random
import bluetooth
import dbus

def _ExceptionHandler(exc_type, exc_value, exc_traceback):
    sys.__excepthook__(exc_type, exc_value, exc_traceback)
    os.kill(os.getpid(), signal.SIGINT)

#This is what gets spawned by the server when it receives a connection.
class Worker(threading.Thread):
    def __init__(self, sock, address):
        threading.Thread.__init__(self)
        self.sock = sock
        self.address = address
        self._logger = logging.getLogger("logger")
        self.stopped = False

    def send_msg(self, message):
        self._logger.info("%s S - %s" % (self.address[0][12:], message))
        self.sock.send(message)

    def get_msg(self):
        data = str(self.sock.recv(1024).decode("utf-8"))
        if len(data) == 0:
            self.stopped = True
        self._logger.info("%s R %s" % (self.address[0][12:], data))
        return data

    def handle_request(self, msg):
        try:
            #self.send_msg("::start::")
            result = subprocess.check_output(msg, shell=True).decode('utf-8').strip()
            if not len(result):
                self.send_msg("the command '%s' returns nothing " % msg)
            for line in result.splitlines():
                self.send_msg(line + " ")
        except:
            self.send_msg("Error when trying to run the command '%s' " % msg)
        #finally:
            #self.send_msg("::end::")

    def run(self):
        try:
            while True:
                self.handle_request(self.get_msg())
                if self.stopped:
                    break
        except Exception as e:
            pass
        self.sock.close()
        self._logger.info("Disconnected from %s" % self.address[0])

class Server():
    def __init__(self):
        self.q_len = 3
        self.port = bluetooth.PORT_ANY
        self.server_sock = None
        self.name = "rpi-bluetooth-server"
        self.uuid = "00001101-0000-1000-8000-00805F9B34FB"
        self._logger = logging.getLogger("logger")
        self._adapter = dbus.Interface(dbus.SystemBus().get_object(
            "org.bluez", "/org/bluez/hci0"), "org.freedesktop.DBus.Properties")
        self._adapter.Set("org.bluez.Adapter1", "Powered", dbus.Boolean(1))
        self.set_host_name()

    def set_host_name(self):
        if not os.path.exists('/etc/bluetooth-id'):
            bt_device_number = ''.join(random.sample((string.digits), 4))
            f = open("/etc/bluetooth-id", "w")
            f.write(bt_device_number)
            f.close()
        else:
            f = open("/etc/bluetooth-id", "r")
            bt_device_number = f.read()
            f.close()

        bt_name = "%s-%s" % (socket.gethostname(), bt_device_number)
        self._device_name = bt_name
        self._logger.info("Setting device name: '%s'", bt_name)
        self._adapter.Set("org.bluez.Adapter1", "Alias", dbus.String(bt_name))

    def hci_config_command(self, command):
        subprocess.call("/bin/hciconfig hci0 %s" % command, shell=True)

    def start_server(self):
        self.hci_config_command("piscan")
        self.server_sock = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
        self.server_sock.bind(("", self.port))
        self.server_sock.listen(self.q_len)  #Queue up as many as 5 connect requests.
        self._logger.info("Listening on port %d" % self.port)

    def advertise_service(self):
        bluetooth.advertise_service(
            self.server_sock,
            self.name,
            service_id=self.uuid,
            service_classes=[self.uuid, bluetooth.SERIAL_PORT_CLASS],
            profiles=[bluetooth.SERIAL_PORT_PROFILE])

    def accept_connections(self):
        while True:
            self._logger.info("Main thread waiting for connections")
            client_sock, address = self.server_sock.accept()
            self._logger.info("Accepted connection from %s" % address[0])
            Worker(client_sock, address).start()  #Spawns the worker thread.

    def set_discoverable(self, discoverable):
        adapter = self._adapter
        if discoverable:
            adapter.Set(
                "org.bluez.Adapter1",
                "DiscoverableTimeout",
                dbus.UInt32(0))
            adapter.Set("org.bluez.Adapter1", "Discoverable", dbus.Boolean(1))
            self.hci_config_command("leadv 3")
            self._logger.info("Discoverable enabled")
        else:
            adapter.Set("org.bluez.Adapter1", "Discoverable", dbus.Boolean(0))
            self.hci_config_command("noleadv")
            self._logger.info("Discoverable disabled")

    def run(self):
        self.set_discoverable(True)
        self.start_server()
        self.advertise_service()
        self.accept_connections()
        self.set_discoverable(False)

    def kill(self):
        self.server_sock.close()
        self.set_discoverable(False)
        sys.exit()

if __name__ == "__main__":
    sys.excepthook = _ExceptionHandler
    logger = logging.getLogger("logger")
    handler = logging.StreamHandler(sys.stdout)
    formatter = logging.Formatter("%(asctime)s: %(message)s")
    logger.addHandler(handler)
    logger.setLevel(logging.DEBUG)
    logger.info("Debug logs enabled")
    try:
        multithreaded_server = Server()
        multithreaded_server.run()
    except KeyboardInterrupt:
        self._logger.info("shutting down the server")
        multithreaded_server.kill()
root@treehouses:~/cli#
```