### PR TITLE
`treehouses services <service> install` sleepy try (fixes #946)

### DIFF
--- a/modules/services.sh
+++ b/modules/services.sh
@@ -103,8 +103,10 @@ function services {
             while [ "$retries" -lt 5 ];
             do
               if ! docker-compose --project-directory /srv/$service_name -f /srv/${service_name}/${service_name}.yml pull ; then
-                echo "retrying pull in 6 seconds"
-                sleep 6
+                if [ "$retries" -lt 4 ]; then
+                  echo "retrying pull in 6 seconds"
+                  sleep 6
+                fi
                 ((retries+=1))
               else
                 echo "${service_name} installed"

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -100,10 +100,11 @@ function services {
             fi
           elif source $SERVICES/install-${service_name}.sh && install ; then
             retries=0
-            while [ "$retries" -lt 2 ];
+            while [ "$retries" -lt 5 ];
             do
               if ! docker-compose --project-directory /srv/$service_name -f /srv/${service_name}/${service_name}.yml pull ; then
-                echo "retrying pull"
+                echo "retrying pull in 6 seconds"
+                sleep 6
                 ((retries+=1))
               else
                 echo "${service_name} installed"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.19.8",
+  "version": "1.19.32",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
```bash
root@treehouses:~/cli# ./cli.sh services nextcloud install
Pulling nextcloud ... done
nextcloud installed
modify default environment variables by running 'cli.sh services nextcloud environment edit'
root@treehouses:~/cli# ./cli.sh services mongodb install
ERROR: The Compose file '/srv/mongodb/mongodb.yml' is invalid because:
services.mongodb.environment contains an invalid type, it should be an object, or an array
retrying pull in 6 seconds
ERROR: The Compose file '/srv/mongodb/mongodb.yml' is invalid because:
services.mongodb.environment contains an invalid type, it should be an object, or an array
retrying pull in 6 seconds
ERROR: The Compose file '/srv/mongodb/mongodb.yml' is invalid because:
services.mongodb.environment contains an invalid type, it should be an object, or an array
retrying pull in 6 seconds
ERROR: The Compose file '/srv/mongodb/mongodb.yml' is invalid because:
services.mongodb.environment contains an invalid type, it should be an object, or an array
retrying pull in 6 seconds
ERROR: The Compose file '/srv/mongodb/mongodb.yml' is invalid because:
services.mongodb.environment contains an invalid type, it should be an object, or an array
retrying pull in 6 seconds
ERROR: cannot pull docker image
root@treehouses:~/cli#

```