### PR TITLE
`treehouses power` (fixes #1052)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ upgrade [tag|check|bluetooth]             upgrades treehouses package using npm
 sshtunnel <add|remove|list|check|notice>  helps adding an sshtunnel
           <key|portinterval> [user@host]
 led [green|red] [mode]                    sets the led mode
-power [mode|freq]                         sets the power mode or check CPU frequency
+power [mode|current|freq]                 sets the power mode or check power mode/CPU frequency
 rtc <on|off> [rasclock|ds3231]            sets up the rtc clock specified
 ntp <local|internet>                      sets rpi to host timing locally or to get timing from a remote server
 networkmode                               outputs the current network mode

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ upgrade [tag|check|bluetooth]             upgrades treehouses package using npm
 sshtunnel <add|remove|list|check|notice>  helps adding an sshtunnel
           <key|portinterval> [user@host]
 led [green|red] [mode]                    sets the led mode
+power [mode|freq]                         sets the power mode or check CPU frequency
 rtc <on|off> [rasclock|ds3231]            sets up the rtc clock specified
 ntp <local|internet>                      sets rpi to host timing locally or to get timing from a remote server
 networkmode                               outputs the current network mode

--- a/_treehouses
+++ b/_treehouses
@@ -219,6 +219,7 @@ treehouses openvpn stop
 treehouses openvpn use
 treehouses password
 treehouses power conservative
+treehouses power current
 treehouses power freq
 treehouses power ondemand
 treehouses power performance

--- a/_treehouses
+++ b/_treehouses
@@ -218,6 +218,11 @@ treehouses openvpn start
 treehouses openvpn stop
 treehouses openvpn use
 treehouses password
+treehouses power conservative
+treehouses power ondemand
+treehouses power performance
+treehouses power powersave
+treehouses power userspace
 treehouses rebootneeded
 treehouses reboots
 treehouses reboots cron

--- a/_treehouses
+++ b/_treehouses
@@ -219,6 +219,7 @@ treehouses openvpn stop
 treehouses openvpn use
 treehouses password
 treehouses power conservative
+treehouses power freq
 treehouses power ondemand
 treehouses power performance
 treehouses power powersave

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -43,6 +43,7 @@ Usage: treehouses
    sshtunnel <add|remove|list|check|notice>  helps adding an sshtunnel
              <key|portinterval> [user@host]
    led [green|red] [mode]                    sets the led mode
+   power [mode]                              sets the power scaling
    rtc <on|off> [rasclock|ds3231]            sets up the rtc clock specified
    ntp <local|internet>                      sets rpi to host timing locally or to get timing from a remote server
    networkmode                               outputs the current network mode

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -43,7 +43,7 @@ Usage: treehouses
    sshtunnel <add|remove|list|check|notice>  helps adding an sshtunnel
              <key|portinterval> [user@host]
    led [green|red] [mode]                    sets the led mode
-   power [mode]                              sets the power scaling
+   power [freq |<mode>]                      sets the power scaling or check CPU frequency
    rtc <on|off> [rasclock|ds3231]            sets up the rtc clock specified
    ntp <local|internet>                      sets rpi to host timing locally or to get timing from a remote server
    networkmode                               outputs the current network mode

--- a/modules/led.sh
+++ b/modules/led.sh
@@ -137,7 +137,7 @@ function led {
     checkroot
 
     if ! grep -q "$trigger" "$led/trigger" 2>"$LOGFILE"; then
-      echo -e "${RED}Error:${NC} unkown led mode '$trigger'"
+      echo -e "${RED}Error:${NC} unknown led mode '$trigger'"
       exit 1
     fi
 

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -3,19 +3,24 @@ function power {
     checkargn $# 2
     mode="$1"
     case "$mode" in
+        threshold)
+            checkroot
+            echo "changing threshold"
+            changethreshhold
+            ;;
         ondemand)
             checkroot
-            echo "ondemand"
+            echo "power setting changed to ondemand"
             changegovernor "ondemand"
             ;;
         conservative)
             checkroot 
-            echo "conservative"
+            echo "power setting changed to conservative"
             changegovernor "conservative"
             ;;
         userspace)
             checkroot
-            echo "userspace"
+            echo "power setting changed to userspace"
             changegovernor "userspace"
             ;;
         powersave)
@@ -29,7 +34,7 @@ function power {
             changegovernor "performance"
             ;; 
         "")
-            echo "please choose one of the 5 modes"
+            echo "Error: please choose one of the 5 modes"
             ;;
         *)
             echo -e "Error: power '$mode' does not exist"
@@ -48,8 +53,11 @@ function changegovernor {
         time='$time'
         syslog='$syslog'
         echo "Set governor to $RESULT"
-        #echo $RESULT > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+        echo "CPU frequency is now $/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"
     else
         echo "Did not recognize mode"
     fi
 }
+
+# TODO: Let user change their CPU threshold
+# cat /sys/devices/system/cpu/cpufreq/ondemand/up_threshold

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -51,11 +51,6 @@ function changegovernor {
     sudo echo $1 | sudo tee /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor > /dev/null 2>&1
     RESULT=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)
     if [ "$RESULT" == "$1" ]; then
-        local_fs='$local_fs'
-        network='$network'
-        named='$named'
-        time='$time'
-        syslog='$syslog'
         echo "Scaling governor set to $RESULT"
     else
         echo "Failure, may need to use sudo"

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -10,17 +10,17 @@ function power {
         #     ;;
         ondemand)
             checkroot
-            echo "Power setting changed to ondemand"
+            echo "Moves speed from min to max at about 90% load"
             changegovernor "ondemand"
             ;;
         conservative)
             checkroot 
-            echo "Power setting changed to conservative"
+            echo "Gradually switch frequencies at about 90% load"
             changegovernor "conservative"
             ;;
         userspace)
             checkroot
-            echo "Power setting changed to userspace"
+            echo "Use user specified frequency" # may need to create new functions to better use this setting
             changegovernor "userspace"
             ;;
         powersave)
@@ -56,9 +56,9 @@ function changegovernor {
         named='$named'
         time='$time'
         syslog='$syslog'
-        echo "Set scaling governor to $RESULT"
+        echo "Scaling governor set to $RESULT"
     else
-        echo "Did not recognize mode"
+        echo "Failure, may need to use sudo"
     fi
 }
 

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -1,93 +1,93 @@
 function power {
-    checkrpi
-    checkargn $# 1
-    mode="$1"
-    case "$mode" in
-        # threshold)
-        #     checkroot
-        #     echo "changing threshold"
-        #     changethreshhold
-        #     ;;
-        current)
-            checkroot
-            echo "Power mode is currently $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)"
-            ;;
-        ondemand)
-            checkroot
-            echo "Moves speed from min to max at about 90% load"
-            changegovernor "ondemand"
-            ;;
-        conservative)
-            checkroot 
-            echo "Gradually switch frequencies at about 90% load"
-            changegovernor "conservative"
-            ;;
-        userspace)
-            checkroot
-            echo "Allows any program to set CPU's frequency"
-            changegovernor "userspace"
-            ;;
-        powersave)
-            checkroot
-            echo "All cores set at minimum frequency"
-            changegovernor "powersave"
-            ;;
-        performance)
-            checkroot
-            echo "All cores set at maximum frequency"
-            changegovernor "performance"
-            ;; 
-        freq)
-            checkroot
-            echo "CPU frequency is now $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq)"
-            ;;
-        "")
-            echo "Error: please choose one of the 5 modes"
-            ;;
-        *)
-            echo -e "Error: power '$mode' does not exist"
-            exit 1
-            ;;
-    esac     
+  checkrpi
+  checkargn $# 1
+  mode="$1"
+  case "$mode" in
+    # threshold)
+    #   checkroot
+    #   echo "changing threshold"
+    #     changethreshhold
+    #     ;;
+    # cat /sys/devices/system/cpu/cpufreq/ondemand/up_threshold
+    current)
+      checkroot
+      echo "Power mode is currently $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)"
+      ;;
+    ondemand)
+      checkroot
+      echo "Moves speed from min to max at about 90% load"
+      changegovernor "ondemand"
+      ;;
+    conservative)
+      checkroot 
+      echo "Gradually switch frequencies at about 90% load"
+      changegovernor "conservative"
+      ;;
+    userspace)
+      checkroot
+      echo "Allows any program to set CPU's frequency"
+      changegovernor "userspace"
+      ;;
+    powersave)
+      checkroot
+      echo "All cores set at minimum frequency"
+      changegovernor "powersave"
+      ;;
+    performance)
+      checkroot
+      echo "All cores set at maximum frequency"
+      changegovernor "performance"
+      ;; 
+    freq)
+      checkroot
+      echo "CPU frequency is now $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq)"
+      ;;
+    "")
+      echo "Error: please choose one of the 5 modes"
+      exit 1
+      ;;
+    *)
+      echo "Error: power '$mode' does not exist"
+      exit 1
+      ;;
+  esac     
 }
 
 function changegovernor {
-    sudo echo $1 | sudo tee /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor > /dev/null 2>&1
-    RESULT=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)
-    if [ "$RESULT" == "$1" ]; then
-        echo "Scaling governor set to $RESULT"
-    else
-        echo "Failure, may need to use sudo"
-    fi
+  sudo echo $1 | sudo tee /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor > /dev/null 2>&1
+  RESULT=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)
+  if [ "$RESULT" == "$1" ]; then
+    echo "Scaling governor set to $RESULT"
+  else
+    echo "Failure, may need to use sudo"
+  fi
 }
 
 function power_help {
-    echo "Usage: $BASENAME power [mode]"
-    echo "       $BASENAME power [current|freq]"
-    echo
-    echo " OPTIONS OF MODES: "
-    echo "  ondemand                    Default mode; moves speed from min to max at about 90% load"
-    echo "  conservative                Gradually switch frequencies at about 90% load"
-    echo "  usespace                    Allows any program to set CPU's frequency"
-    echo "  powersave                   All cores set at minimum frequency"
-    echo "  performance                 All cores set at maximum frequency"
-    echo
-    echo "Example:"
-    echo "  $BASENAME power ondemand" 
-    echo "      This will set the power mode to ondemand" 
-    echo "  $BASENAME power conservative" 
-    echo "      This will set the power mode to conservative" 
-    echo "  $BASENAME power usespace" 
-    echo "      This will set the power mode to userspace" 
-    echo "  $BASENAME power powersave" 
-    echo "      This will set the power mode to powersave" 
-    echo "  $BASENAME power performance" 
-    echo "      This will set the power mode to performance" 
-    echo "  $BASENAME power current" 
-    echo "      This will return the current power mode" 
-    echo "  $BASENAME power freq" 
-    echo "      This will return the current CPU frequency" 
-    echo
+  echo "Usage: $BASENAME power [mode]"
+  echo "       $BASENAME power [current|freq]"
+  echo
+  echo "Options of modes:"
+  echo "  ondemand                    Default mode; moves speed from min to max at about 90% load"
+  echo "  conservative                Gradually switch frequencies at about 90% load"
+  echo "  usespace                    Allows any program to set CPU's frequency"
+  echo "  powersave                   All cores set at minimum frequency"
+  echo "  performance                 All cores set at maximum frequency"
+  echo
+  echo "Example:"
+  echo "  $BASENAME power ondemand" 
+  echo "      This will set the power mode to ondemand" 
+  echo "  $BASENAME power conservative" 
+  echo "      This will set the power mode to conservative" 
+  echo "  $BASENAME power usespace" 
+  echo "      This will set the power mode to userspace" 
+  echo "  $BASENAME power powersave" 
+  echo "      This will set the power mode to powersave" 
+  echo "  $BASENAME power performance" 
+  echo "      This will set the power mode to performance" 
+  echo "  $BASENAME power current" 
+  echo "      This will return the current power mode" 
+  echo "  $BASENAME power freq" 
+  echo "      This will return the current CPU frequency" 
+  echo
 }
-# TODO: Let user change their CPU threshold
-# cat /sys/devices/system/cpu/cpufreq/ondemand/up_threshold

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -28,6 +28,13 @@ function power {
             echo "all cores set at maximum frequency"
             changegovernor "performance"
             ;; 
+        "")
+            echo "please choose one of the 5 modes"
+            ;;
+        *)
+            echo -e "Error: power '$mode' does not exist"
+            exit 1
+            ;;
     esac     
 }
 

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -1,0 +1,45 @@
+function power{
+    mode="$1"
+    case "$mode" in
+        ondemand)
+            checkroot
+            echo "ondemand"
+            changegovernor "ondemand"
+            ;;
+        conservative)
+            checkroot 
+            echo "conservative"
+            changegovernor "conservative"
+            ;;
+        userspace)
+            checkroot
+            echo "userspace"
+            changegovernor "userspace"
+            ;;
+        powersave)
+            checkroot
+            echo "all cores set at minimum frequency"
+            changegovernor "powersave"
+            ;;
+        performance)
+            checkroot
+            echo "all cores set at maximum frequency"
+            changegovernor "performance"
+            ;; 
+        "")     
+}
+
+function changegovernor(){
+    sudo echo $1 | sudo tee /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor > /dev/null 2>&1
+    RESULT=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)
+    if [ "$RESULT" == "$1" ]; then
+        local_fs='$local_fs'
+        network='$network'
+        named='$named'
+        time='$time'
+        syslog='$syslog'
+        echo "Set governor to $RESULT"
+        #echo $RESULT > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+    else
+        echo "Did not recognize mode"
+}

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -53,7 +53,7 @@ function changegovernor {
         time='$time'
         syslog='$syslog'
         echo "Set governor to $RESULT"
-        echo "CPU frequency is now ${/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq}"
+        echo "CPU frequency is now $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq)"
     else
         echo "Did not recognize mode"
     fi

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -43,6 +43,6 @@ function changegovernor {
         echo "Set governor to $RESULT"
         #echo $RESULT > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
     else
-        echo "Did not recognize mode"\
+        echo "Did not recognize mode"
     fi
 }

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -1,4 +1,4 @@
-function power{
+function power {
     checkrpi
     checkargn $# 2
     mode="$1"
@@ -31,7 +31,7 @@ function power{
         "")     
 }
 
-function changegovernor{
+function changegovernor {
     sudo echo $1 | sudo tee /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor > /dev/null 2>&1
     RESULT=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)
     if [ "$RESULT" == "$1" ]; then

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -28,7 +28,7 @@ function power {
             echo "all cores set at maximum frequency"
             changegovernor "performance"
             ;; 
-        *)     
+    esac     
 }
 
 function changegovernor {

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -3,36 +3,40 @@ function power {
     checkargn $# 2
     mode="$1"
     case "$mode" in
-        threshold)
-            checkroot
-            echo "changing threshold"
-            changethreshhold
-            ;;
+        # threshold)
+        #     checkroot
+        #     echo "changing threshold"
+        #     changethreshhold
+        #     ;;
         ondemand)
             checkroot
-            echo "power setting changed to ondemand"
+            echo "Power setting changed to ondemand"
             changegovernor "ondemand"
             ;;
         conservative)
             checkroot 
-            echo "power setting changed to conservative"
+            echo "Power setting changed to conservative"
             changegovernor "conservative"
             ;;
         userspace)
             checkroot
-            echo "power setting changed to userspace"
+            echo "Power setting changed to userspace"
             changegovernor "userspace"
             ;;
         powersave)
             checkroot
-            echo "all cores set at minimum frequency"
+            echo "All cores set at minimum frequency"
             changegovernor "powersave"
             ;;
         performance)
             checkroot
-            echo "all cores set at maximum frequency"
+            echo "All cores set at maximum frequency"
             changegovernor "performance"
             ;; 
+        freq)
+            checkroot
+            echo "CPU frequency is now $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq)"
+            ;;
         "")
             echo "Error: please choose one of the 5 modes"
             ;;
@@ -52,8 +56,7 @@ function changegovernor {
         named='$named'
         time='$time'
         syslog='$syslog'
-        echo "Set governor to $RESULT"
-        echo "CPU frequency is now $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq)"
+        echo "Set scaling governor to $RESULT"
     else
         echo "Did not recognize mode"
     fi

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -1,4 +1,6 @@
 function power{
+    checkrpi
+    checkargn $# 2
     mode="$1"
     case "$mode" in
         ondemand)
@@ -29,7 +31,7 @@ function power{
         "")     
 }
 
-function changegovernor(){
+function changegovernor{
     sudo echo $1 | sudo tee /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor > /dev/null 2>&1
     RESULT=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)
     if [ "$RESULT" == "$1" ]; then

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -43,5 +43,6 @@ function changegovernor {
         echo "Set governor to $RESULT"
         #echo $RESULT > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
     else
-        echo "Did not recognize mode"
+        echo "Did not recognize mode"\
+    fi
 }

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -24,7 +24,7 @@ function power {
             ;;
         userspace)
             checkroot
-            echo "Use user specified frequency" # may need to create new functions to better use this setting
+            echo "Allows any program to set CPU's frequency"
             changegovernor "userspace"
             ;;
         powersave)
@@ -68,7 +68,7 @@ function power_help {
     echo " OPTIONS OF MODES: "
     echo "  ondemand                    Default mode; moves speed from min to max at about 90% load"
     echo "  conservative                Gradually switch frequencies at about 90% load"
-    echo "  usespace                    Use user specified frequency"
+    echo "  usespace                    Allows any program to set CPU's frequency"
     echo "  powersave                   All cores set at minimum frequency"
     echo "  performance                 All cores set at maximum frequency"
     echo
@@ -88,8 +88,6 @@ function power_help {
     echo "  $BASENAME power freq" 
     echo "      This will return the current CPU frequency" 
     echo
-
- 
 }
 # TODO: Let user change their CPU threshold
 # cat /sys/devices/system/cpu/cpufreq/ondemand/up_threshold

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -11,6 +11,7 @@ function power {
         current)
             checkroot
             echo "Power mode is currently $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)"
+            ;;
         ondemand)
             checkroot
             echo "Moves speed from min to max at about 90% load"
@@ -62,9 +63,7 @@ function changegovernor {
 
 function power_help {
     echo "Usage: $BASENAME power [mode]"
-    echo "       $BASENAME power freq"
-    echo
-    echo " Where to find all modes: cat /sys/class/leds/led0/trigger"
+    echo "       $BASENAME power [current|freq]"
     echo
     echo " OPTIONS OF MODES: "
     echo "  ondemand                    Default mode; moves speed from min to max at about 90% load"
@@ -84,6 +83,8 @@ function power_help {
     echo "      This will set the power mode to powersave" 
     echo "  $BASENAME power performance" 
     echo "      This will set the power mode to performance" 
+    echo "  $BASENAME power current" 
+    echo "      This will return the current power mode" 
     echo "  $BASENAME power freq" 
     echo "      This will return the current CPU frequency" 
     echo

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -53,7 +53,7 @@ function changegovernor {
         time='$time'
         syslog='$syslog'
         echo "Set governor to $RESULT"
-        echo "CPU frequency is now $/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"
+        echo "CPU frequency is now ${/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq}"
     else
         echo "Did not recognize mode"
     fi

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -1,6 +1,6 @@
 function power {
     checkrpi
-    checkargn $# 2
+    checkargn $# 1
     mode="$1"
     case "$mode" in
         # threshold)
@@ -57,5 +57,35 @@ function changegovernor {
     fi
 }
 
+function power_help {
+    echo "Usage: $BASENAME power [mode]"
+    echo "       $BASENAME power freq"
+    echo
+    echo " Where to find all modes: cat /sys/class/leds/led0/trigger"
+    echo
+    echo " OPTIONS OF MODES: "
+    echo "  ondemand                    Default mode; moves speed from min to max at about 90% load"
+    echo "  conservative                Gradually switch frequencies at about 90% load"
+    echo "  usespace                    Use user specified frequency"
+    echo "  powersave                   All cores set at minimum frequency"
+    echo "  performance                 All cores set at maximum frequency"
+    echo
+    echo "Example:"
+    echo "  $BASENAME power ondemand" 
+    echo "      This will set the power mode to ondemand" 
+    echo "  $BASENAME power conservative" 
+    echo "      This will set the power mode to conservative" 
+    echo "  $BASENAME power usespace" 
+    echo "      This will set the power mode to userspace" 
+    echo "  $BASENAME power powersave" 
+    echo "      This will set the power mode to powersave" 
+    echo "  $BASENAME power performance" 
+    echo "      This will set the power mode to performance" 
+    echo "  $BASENAME power freq" 
+    echo "      This will return the current CPU frequency" 
+    echo
+
+ 
+}
 # TODO: Let user change their CPU threshold
 # cat /sys/devices/system/cpu/cpufreq/ondemand/up_threshold

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -28,7 +28,7 @@ function power {
             echo "all cores set at maximum frequency"
             changegovernor "performance"
             ;; 
-        "")     
+        *)     
 }
 
 function changegovernor {

--- a/modules/power.sh
+++ b/modules/power.sh
@@ -8,6 +8,9 @@ function power {
         #     echo "changing threshold"
         #     changethreshhold
         #     ;;
+        current)
+            checkroot
+            echo "Power mode is currently $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)"
         ondemand)
             checkroot
             echo "Moves speed from min to max at about 90% load"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.19.19",
+  "version": "1.19.20",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Fixes #1052 

`treehouses power <scaling_governor_setting>`
There are 5 scaling governor settings that the RPi can switch to:
1. `ondemand`: **default**, moves speed from min to max and back at a % of load
1. `conservative` : gradually switch frequencies at % of load
1. `userspace` : use user specified frequencies
1. `powersave`: all cores set at minimum frequency
1. `performance` : all cores set at maximum frequency
 
`treehouses power freq` can be used to check the CPU frequency.