### PR TITLE
`treehouses password disable/enable` (fixes #540)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ help [command]                            gives you a more detailed info about t
 verbose <on|off>                          makes each command print more output (might not work with treehouses remote)
 expandfs                                  expands the partition of the RPI image to the maximum of the SDcard
 rename <hostname>                         changes hostname
-password <password>                       changes the password for 'pi' user
+password <password|disable|enable>        changes the password for 'pi' user or disables/enables password authentication
 sshkey <add|list|delete|deleteall|github> used for adding or removing ssh keys for authentication
 version [contributors]                    returns the version of cli.sh command
 image                                     returns version of the system image installed

--- a/_treehouses
+++ b/_treehouses
@@ -219,6 +219,8 @@ treehouses openvpn start
 treehouses openvpn stop
 treehouses openvpn use
 treehouses password
+treehouses password disable
+treehouses password enable
 treehouses rebootneeded
 treehouses reboots
 treehouses reboots cron

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -6,7 +6,7 @@ Usage: treehouses
    verbose <on|off>                          makes each command print more output (might not work with treehouses remote)
    expandfs                                  expands the partition of the RPI image to the maximum of the SDcard
    rename <hostname>                         changes hostname
-   password <password>                       changes the password for 'pi' user
+   password <password|disable|enable>        changes the password for 'pi' user or disables/enables password authentication
    sshkey <add|list|delete|deleteall|github> used for adding or removing ssh keys for authentication
    version [contributors]                    returns the version of treehouses command
    image                                     returns version of the system image installed

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -18,7 +18,7 @@ function disablepassword {
   if grep -Fxq "#PasswordAuthentication yes" /etc/ssh/sshd_config || grep -Fxq "#PasswordAuthentication no" /etc/ssh/sshd_config
   then
     sed -i "s/^#PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config 
-    "Successfully enabled password authentication" 
+    echo "Successfully disabled password authentication" 
   elif grep -Fxq "PasswordAuthentication no" /etc/ssh/sshd_config 
   then
     log_and_exit1 "Password authentication is already disabled"
@@ -32,7 +32,7 @@ function enablepassword {
   if grep -Fxq "#PasswordAuthentication yes" /etc/ssh/sshd_config || grep -Fxq "#PasswordAuthentication no" /etc/ssh/sshd_config
   then
     sed -i "s/^#PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_config
-    "Successfully enabled password authentication"
+    echo "Successfully enabled password authentication"
   elif grep -Fxq "PasswordAuthentication yes" /etc/ssh/sshd_config 
   then
     log_and_exit1 "Password authentication is already enabled"

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -13,7 +13,11 @@ function password {
 }
 
 function disablepassword {
-  sed -i "s/^PasswordAuthentication*/PasswordAuthentication no/" /etc/ssh/sshd_config
+  if [grep -Fxq "s/^PasswordAuthentication no" /etc/ssh/sshd_config]; then
+    log_an_exit1 "Password authentication is already disabled"
+  else
+    sed -i "s/^#PasswordAuthentication*/PasswordAuthentication no/" /etc/ssh/sshd_config
+  fi
 }
 
 function password_help {

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -15,9 +15,9 @@ function password {
 }
 
 function disablepassword {
-  if grep -EFxq "#PasswordAuthentication yes|no" /etc/ssh/sshd_config 
+  if grep -EFxq "#PasswordAuthentication" /etc/ssh/sshd_config 
   then
-    sed -in "s/^#PasswordAuthentication yes{no}/PasswordAuthentication no/" /etc/ssh/sshd_config 
+    sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication no/" /etc/ssh/sshd_config 
     echo "Successfully disabled password authentication" 
   elif grep -Fxq "PasswordAuthentication no" /etc/ssh/sshd_config 
   then
@@ -29,9 +29,9 @@ function disablepassword {
 }
 
 function enablepassword {
-  if grep -EFxq "#PasswordAuthentication yes|no" /etc/ssh/sshd_config
+  if grep -EFxq "#PasswordAuthentication" /etc/ssh/sshd_config
   then
-    sed -in "s/^#PasswordAuthentication no{yes}/PasswordAuthentication yes/" /etc/ssh/sshd_config
+    sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"
   elif grep -Fxq "PasswordAuthentication yes" /etc/ssh/sshd_config 
   then

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -15,7 +15,7 @@ function password {
 }
 
 function disablepassword {
-  if grep -EFxq "#PasswordAuthentication" /etc/ssh/sshd_config 
+  if grep -Fxq "#PasswordAuthentication" /etc/ssh/sshd_config 
   then
     sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication no/" /etc/ssh/sshd_config 
     echo "Successfully disabled password authentication" 
@@ -29,7 +29,7 @@ function disablepassword {
 }
 
 function enablepassword {
-  if grep -EFxq "#PasswordAuthentication" /etc/ssh/sshd_config
+  if grep -Fxq "#PasswordAuthentication" /etc/ssh/sshd_config
   then
     sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -4,7 +4,7 @@ function password () {
   checkargn $# 1
   if [[ $1 == "" ]]; then
     log_and_exit1 "Error: Password not entered"
-  else if [[ $1 == "disable"]]; then
+  elif [[ $1 == "disable"]]; then
     disablepassword 
   else
     chpasswd <<< "pi:$1"

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -15,7 +15,7 @@ function password {
 }
 
 function disablepassword {
-  if grep -EFxq "#PasswordAuthentication" /etc/ssh/sshd_config 
+  if grep -EFxq "#PasswordAuthentication yes|no" /etc/ssh/sshd_config 
   then
     sed -in "s/^#PasswordAuthentication yes{no}/PasswordAuthentication no/" /etc/ssh/sshd_config 
     echo "Successfully disabled password authentication" 
@@ -29,7 +29,7 @@ function disablepassword {
 }
 
 function enablepassword {
-  if grep -EFxq "#PasswordAuthentication" /etc/ssh/sshd_config
+  if grep -EFxq "#PasswordAuthentication yes|no" /etc/ssh/sshd_config
   then
     sed -in "s/^#PasswordAuthentication no{yes}/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -17,7 +17,7 @@ function password {
 function disablepassword {
   if grep -EFxq "#PasswordAuthentication" /etc/ssh/sshd_config 
   then
-    sed -i "s/^#PasswordAuthentication yes{no}/PasswordAuthentication no/" /etc/ssh/sshd_config 
+    sed -in "s/^#PasswordAuthentication yes{no}/PasswordAuthentication no/" /etc/ssh/sshd_config 
     echo "Successfully disabled password authentication" 
   elif grep -Fxq "PasswordAuthentication no" /etc/ssh/sshd_config 
   then
@@ -31,7 +31,7 @@ function disablepassword {
 function enablepassword {
   if grep -EFxq "#PasswordAuthentication" /etc/ssh/sshd_config
   then
-    sed -i "s/^#PasswordAuthentication no{yes}/PasswordAuthentication yes/" /etc/ssh/sshd_config
+    sed -in "s/^#PasswordAuthentication no{yes}/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"
   elif grep -Fxq "PasswordAuthentication yes" /etc/ssh/sshd_config 
   then

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -1,4 +1,4 @@
-function password () {
+function password {
   checkrpi
   checkroot
   checkargn $# 1
@@ -12,11 +12,11 @@ function password () {
   fi
 }
 
-function disablepassword() {
+function disablepassword {
   sed -i "s/^PasswordAuthentication*/PasswordAuthentication no/" /etc/ssh/sshd_config
 }
 
-function password_help () {
+function password_help {
   echo
   echo "Usage: $BASENAME password <password>"
   echo

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -15,7 +15,7 @@ function password {
 }
 
 function disablepassword {
-  if grep -Fxq "#PasswordAuthentication" /etc/ssh/sshd_config 
+  if grep -Fxq "#PasswordAuthentication.*" /etc/ssh/sshd_config 
   then
     sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication no/" /etc/ssh/sshd_config 
     echo "Successfully disabled password authentication" 
@@ -29,7 +29,7 @@ function disablepassword {
 }
 
 function enablepassword {
-  if grep -Fxq "#PasswordAuthentication" /etc/ssh/sshd_config
+  if grep -Fxq "#PasswordAuthentication.*" /etc/ssh/sshd_config
   then
     sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -15,7 +15,7 @@ function password {
 function disablepassword {
   if grep -Fxq "PasswordAuthentication no" /etc/ssh/sshd_config 
   then
-    log_an_exit1 "Password authentication is already disabled"
+    log_and_exit1 "Password authentication is already disabled"
   else
     sed -i "s/^#PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config
     echo "Successfully disabled password authentication"

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -15,9 +15,9 @@ function password {
 }
 
 function disablepassword {
-  if grep -Fxq "#PasswordAuthentication yes" /etc/ssh/sshd_config || grep -Fxq "#PasswordAuthentication no" /etc/ssh/sshd_config
+  if grep -EFxq "#PasswordAuthentication" /etc/ssh/sshd_config 
   then
-    sed -i "s/^#PasswordAuthentication$/PasswordAuthentication no/" /etc/ssh/sshd_config 
+    sed -i "s/^#PasswordAuthentication yes{no}/PasswordAuthentication no/" /etc/ssh/sshd_config 
     echo "Successfully disabled password authentication" 
   elif grep -Fxq "PasswordAuthentication no" /etc/ssh/sshd_config 
   then
@@ -29,9 +29,9 @@ function disablepassword {
 }
 
 function enablepassword {
-  if grep -Fxq "#PasswordAuthentication yes" /etc/ssh/sshd_config || grep -Fxq "#PasswordAuthentication no" /etc/ssh/sshd_config
+  if grep -EFxq "#PasswordAuthentication" /etc/ssh/sshd_config
   then
-    sed -i "s/^#PasswordAuthentication$/PasswordAuthentication yes/" /etc/ssh/sshd_config
+    sed -i "s/^#PasswordAuthentication no{yes}/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"
   elif grep -Fxq "PasswordAuthentication yes" /etc/ssh/sshd_config 
   then

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -13,10 +13,12 @@ function password {
 }
 
 function disablepassword {
-  if grep -Fxq "s/^PasswordAuthentication no" /etc/ssh/sshd_config then
+  if grep -Fxq "s/^PasswordAuthentication no" /etc/ssh/sshd_config 
+  then
     log_an_exit1 "Password authentication is already disabled"
   else
     sed -i "s/^#PasswordAuthentication*/PasswordAuthentication no/" /etc/ssh/sshd_config
+    echo "Successfully disabled password authentication"
   fi
 }
 

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -13,7 +13,7 @@ function password {
 }
 
 function disablepassword {
-  if grep -Fxq "s/^PasswordAuthentication no" /etc/ssh/sshd_config 
+  if grep -Fxq "s/^PasswordAuthentication no/" /etc/ssh/sshd_config 
   then
     log_an_exit1 "Password authentication is already disabled"
   else

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -15,34 +15,36 @@ function password {
 }
 
 function disablepassword {
+  checkroot
   if grep -Fq "#PasswordAuthentication" /etc/ssh/sshd_config 
   then
     sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication no/" /etc/ssh/sshd_config 
     echo "Successfully disabled password authentication"
-    echo /etc/init.d/ssh reload 
+    /etc/init.d/ssh reload 
   elif grep -Fxq "PasswordAuthentication no" /etc/ssh/sshd_config 
   then
     log_and_exit1 "Password authentication is already disabled"
   else
     sed -i "s/^PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config
     echo "Successfully disabled password authentication"
-    echo /etc/init.d/ssh reload
+    /etc/init.d/ssh reload
   fi
 }
 
 function enablepassword {
+  checkroot
   if grep -Fq "#PasswordAuthentication" /etc/ssh/sshd_config
   then
     sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"
-    echo /etc/init.d/ssh reload
+    /etc/init.d/ssh reload
   elif grep -Fxq "PasswordAuthentication yes" /etc/ssh/sshd_config 
   then
     log_and_exit1 "Password authentication is already enabled"
   else
     sed -i "s/^PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"
-    echo /etc/init.d/ssh reload
+    /etc/init.d/ssh reload
   fi
 }
 function password_help {

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -17,7 +17,7 @@ function password {
 function disablepassword {
   if grep -Fxq "#PasswordAuthentication yes" /etc/ssh/sshd_config || grep -Fxq "#PasswordAuthentication no" /etc/ssh/sshd_config
   then
-    sed -i "s/^#PasswordAuthentication /PasswordAuthentication no/" /etc/ssh/sshd_config 
+    sed -i "s/^#PasswordAuthentication*/PasswordAuthentication no/" /etc/ssh/sshd_config 
     echo "Successfully disabled password authentication" 
   elif grep -Fxq "PasswordAuthentication no" /etc/ssh/sshd_config 
   then
@@ -31,7 +31,7 @@ function disablepassword {
 function enablepassword {
   if grep -Fxq "#PasswordAuthentication yes" /etc/ssh/sshd_config || grep -Fxq "#PasswordAuthentication no" /etc/ssh/sshd_config
   then
-    sed -i "s/^#PasswordAuthentication /PasswordAuthentication yes/" /etc/ssh/sshd_config
+    sed -i "s/^#PasswordAuthentication*/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"
   elif grep -Fxq "PasswordAuthentication yes" /etc/ssh/sshd_config 
   then

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -4,7 +4,7 @@ function password {
   checkargn $# 1
   if [[ $1 == "" ]]; then
     log_and_exit1 "Error: Password not entered"
-  elif [[ $1 == "disable"]]; then
+  elif [ $1 == "disable" ]; then
     disablepassword 
   else
     chpasswd <<< "pi:$1"

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -15,7 +15,7 @@ function password {
 }
 
 function disablepassword {
-  if grep -Fq "#PasswordAuthentication.*" /etc/ssh/sshd_config 
+  if grep -Fq "#PasswordAuthentication" /etc/ssh/sshd_config 
   then
     sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication no/" /etc/ssh/sshd_config 
     echo "Successfully disabled password authentication" 
@@ -29,7 +29,7 @@ function disablepassword {
 }
 
 function enablepassword {
-  if grep -Fq "#PasswordAuthentication.*" /etc/ssh/sshd_config
+  if grep -Fq "#PasswordAuthentication" /etc/ssh/sshd_config
   then
     sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -4,7 +4,7 @@ function password () {
   checkargn $# 1
   if [[ $1 == "" ]]; then
     log_and_exit1 "Error: Password not entered"
-  else if [[ $1 == "disable"]]
+  else if [[ $1 == "disable"]]; then
     disablepassword 
   else
     chpasswd <<< "pi:$1"

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -13,7 +13,7 @@ function password {
 }
 
 function disablepassword {
-  if grep -Fxq "s/^PasswordAuthentication no/" /etc/ssh/sshd_config 
+  if grep -Fxq "PasswordAuthentication no" /etc/ssh/sshd_config 
   then
     log_an_exit1 "Password authentication is already disabled"
   else

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -13,7 +13,7 @@ function password {
 }
 
 function disablepassword {
-  if [grep -Fxq "s/^PasswordAuthentication no" /etc/ssh/sshd_config]; then
+  if grep -Fxq "s/^PasswordAuthentication no" /etc/ssh/sshd_config then
     log_an_exit1 "Password authentication is already disabled"
   else
     sed -i "s/^#PasswordAuthentication*/PasswordAuthentication no/" /etc/ssh/sshd_config

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -15,7 +15,7 @@ function password {
 }
 
 function disablepassword {
-  if grep -Fxq "#PasswordAuthentication.*" /etc/ssh/sshd_config 
+  if grep -Fq "#PasswordAuthentication.*" /etc/ssh/sshd_config 
   then
     sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication no/" /etc/ssh/sshd_config 
     echo "Successfully disabled password authentication" 
@@ -29,7 +29,7 @@ function disablepassword {
 }
 
 function enablepassword {
-  if grep -Fxq "#PasswordAuthentication.*" /etc/ssh/sshd_config
+  if grep -Fq "#PasswordAuthentication.*" /etc/ssh/sshd_config
   then
     sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -15,7 +15,11 @@ function password {
 }
 
 function disablepassword {
-  if grep -Fxq "PasswordAuthentication no" /etc/ssh/sshd_config 
+  if grep -Fxq "#PasswordAuthentication yes" /etc/ssh/sshd_config || grep -Fxq "#PasswordAuthentication no" /etc/ssh/sshd_config
+  then
+    sed -i "s/^#PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config 
+    "Successfully enabled password authentication" 
+  elif grep -Fxq "PasswordAuthentication no" /etc/ssh/sshd_config 
   then
     log_and_exit1 "Password authentication is already disabled"
   else
@@ -25,22 +29,30 @@ function disablepassword {
 }
 
 function enablepassword {
-  if grep -Fxq "PasswordAuthentication yes" /etc/ssh/sshd_config 
+  if grep -Fxq "#PasswordAuthentication yes" /etc/ssh/sshd_config || grep -Fxq "#PasswordAuthentication no" /etc/ssh/sshd_config
+  then
+    sed -i "s/^#PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_config
+    "Successfully enabled password authentication"
+  elif grep -Fxq "PasswordAuthentication yes" /etc/ssh/sshd_config 
   then
     log_and_exit1 "Password authentication is already enabled"
   else
     sed -i "s/^PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_config
-    echo "Successfully disabled password authentication"
+    echo "Successfully enabled password authentication"
   fi
 }
 function password_help {
   echo
   echo "Usage: $BASENAME password <password>"
+  echo "       $BASENAME password [disable|enable]"
   echo
   echo "Changes the password for 'pi' user"
   echo
   echo "Example:"
   echo "  $BASENAME password ABC"
   echo "      Sets the password for 'pi' user to 'ABC'."
-  echo
+  echo "  $BASENAME password disable"
+  echo "      Disables password authentication (only passphrase allowed)"
+  echo "  $BASENAME password enable"
+  echo "      Enables password authentiaction (password or passphrase allowed)"
 }

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -17,7 +17,7 @@ function disablepassword {
   then
     log_an_exit1 "Password authentication is already disabled"
   else
-    sed -i "s/^#PasswordAuthentication*/PasswordAuthentication no/" /etc/ssh/sshd_config
+    sed -i "s/^#PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config
     echo "Successfully disabled password authentication"
   fi
 }

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -18,13 +18,15 @@ function disablepassword {
   if grep -Fq "#PasswordAuthentication" /etc/ssh/sshd_config 
   then
     sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication no/" /etc/ssh/sshd_config 
-    echo "Successfully disabled password authentication" 
+    echo "Successfully disabled password authentication"
+    echo /etc/init.d/ssh reload 
   elif grep -Fxq "PasswordAuthentication no" /etc/ssh/sshd_config 
   then
     log_and_exit1 "Password authentication is already disabled"
   else
     sed -i "s/^PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config
     echo "Successfully disabled password authentication"
+    echo /etc/init.d/ssh reload
   fi
 }
 
@@ -33,12 +35,14 @@ function enablepassword {
   then
     sed -in "s/^#PasswordAuthentication.*/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"
+    echo /etc/init.d/ssh reload
   elif grep -Fxq "PasswordAuthentication yes" /etc/ssh/sshd_config 
   then
     log_and_exit1 "Password authentication is already enabled"
   else
     sed -i "s/^PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"
+    echo /etc/init.d/ssh reload
   fi
 }
 function password_help {

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -17,7 +17,7 @@ function password {
 function disablepassword {
   if grep -Fxq "#PasswordAuthentication yes" /etc/ssh/sshd_config || grep -Fxq "#PasswordAuthentication no" /etc/ssh/sshd_config
   then
-    sed -i "s/^#PasswordAuthentication*/PasswordAuthentication no/" /etc/ssh/sshd_config 
+    sed -i "s/^#PasswordAuthentication$/PasswordAuthentication no/" /etc/ssh/sshd_config 
     echo "Successfully disabled password authentication" 
   elif grep -Fxq "PasswordAuthentication no" /etc/ssh/sshd_config 
   then
@@ -31,7 +31,7 @@ function disablepassword {
 function enablepassword {
   if grep -Fxq "#PasswordAuthentication yes" /etc/ssh/sshd_config || grep -Fxq "#PasswordAuthentication no" /etc/ssh/sshd_config
   then
-    sed -i "s/^#PasswordAuthentication*/PasswordAuthentication yes/" /etc/ssh/sshd_config
+    sed -i "s/^#PasswordAuthentication$/PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"
   elif grep -Fxq "PasswordAuthentication yes" /etc/ssh/sshd_config 
   then

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -6,6 +6,8 @@ function password {
     log_and_exit1 "Error: Password not entered"
   elif [ $1 == "disable" ]; then
     disablepassword 
+  elif [ $1 == "enable" ]; then
+    enablepassword
   else
     chpasswd <<< "pi:$1"
     echo "Success: the password has been changed"
@@ -17,11 +19,20 @@ function disablepassword {
   then
     log_and_exit1 "Password authentication is already disabled"
   else
-    sed -i "s/^#PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config
+    sed -i "s/^PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config
     echo "Successfully disabled password authentication"
   fi
 }
 
+function enablepassword {
+  if grep -Fxq "PasswordAuthentication yes" /etc/ssh/sshd_config 
+  then
+    log_and_exit1 "Password authentication is already enabled"
+  else
+    sed -i "s/^PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_config
+    echo "Successfully disabled password authentication"
+  fi
+}
 function password_help {
   echo
   echo "Usage: $BASENAME password <password>"

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -4,10 +4,16 @@ function password () {
   checkargn $# 1
   if [[ $1 == "" ]]; then
     log_and_exit1 "Error: Password not entered"
+  else if [[ $1 == "disable"]]
+    disablepassword 
   else
     chpasswd <<< "pi:$1"
     echo "Success: the password has been changed"
   fi
+}
+
+function disablepassword() {
+  sed -i "s/^PasswordAuthentication*/PasswordAuthentication no/" /etc/ssh/sshd_config
 }
 
 function password_help () {

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -17,7 +17,7 @@ function password {
 function disablepassword {
   if grep -Fxq "#PasswordAuthentication yes" /etc/ssh/sshd_config || grep -Fxq "#PasswordAuthentication no" /etc/ssh/sshd_config
   then
-    sed -i "s/^#PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config 
+    sed -i "s/^#PasswordAuthentication /PasswordAuthentication no/" /etc/ssh/sshd_config 
     echo "Successfully disabled password authentication" 
   elif grep -Fxq "PasswordAuthentication no" /etc/ssh/sshd_config 
   then
@@ -31,7 +31,7 @@ function disablepassword {
 function enablepassword {
   if grep -Fxq "#PasswordAuthentication yes" /etc/ssh/sshd_config || grep -Fxq "#PasswordAuthentication no" /etc/ssh/sshd_config
   then
-    sed -i "s/^#PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_config
+    sed -i "s/^#PasswordAuthentication /PasswordAuthentication yes/" /etc/ssh/sshd_config
     echo "Successfully enabled password authentication"
   elif grep -Fxq "PasswordAuthentication yes" /etc/ssh/sshd_config 
   then


### PR DESCRIPTION
Fixes #540 

`treehouses password [disable | enable]`

Disables/enables password login for `ssh pi@<ip-address>`. Currently, you can enter a password if you press `Enter` after the passphrase prompt. 

The `PasswordAuthentication` field is modified in the `/etc/ssh/ssh_config` file.
Use `vi /etc/ssh/ssh_config` to inspect the field.

![image](https://user-images.githubusercontent.com/35390215/80855496-a6429180-8c0f-11ea-8a80-3cf9b2300054.png)

