### PR TITLE
`treehouses password disable` & `enable` (fixes #540)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ help [command]                            gives you a more detailed info about t
 verbose <on|off>                          makes each command print more output (might not work with treehouses remote)
 expandfs                                  expands the partition of the RPI image to the maximum of the SDcard
 rename <hostname>                         changes hostname
-password <password>                       changes the password for 'pi' user
+password <password|disable|enable>        changes the password for 'pi' user or disables/enables password authentication
 sshkey <add|list|delete|deleteall|github> used for adding or removing ssh keys for authentication
 version [contributors]                    returns the version of cli.sh command
 image                                     returns version of the system image installed

--- a/_treehouses
+++ b/_treehouses
@@ -219,6 +219,8 @@ treehouses openvpn start
 treehouses openvpn stop
 treehouses openvpn use
 treehouses password
+treehouses password disable
+treehouses password enable
 treehouses power conservative
 treehouses power current
 treehouses power freq

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -6,7 +6,7 @@ Usage: treehouses
    verbose <on|off>                          makes each command print more output (might not work with treehouses remote)
    expandfs                                  expands the partition of the RPI image to the maximum of the SDcard
    rename <hostname>                         changes hostname
-   password <password>                       changes the password for 'pi' user
+   password <password|disable|enable>        changes the password for 'pi' user or disables/enables password authentication
    sshkey <add|list|delete|deleteall|github> used for adding or removing ssh keys for authentication
    version [contributors]                    returns the version of treehouses command
    image                                     returns version of the system image installed

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -1,23 +1,41 @@
-function password () {
+function password {
   checkrpi
   checkroot
   checkargn $# 1
   if [[ $1 == "" ]]; then
     log_and_exit1 "Error: Password not entered"
+  elif [ $1 == "disable" ]; then
+    disablepassword 
+  elif [ $1 == "enable" ]; then
+    enablepassword
   else
     chpasswd <<< "pi:$1"
     echo "Success: the password has been changed"
   fi
 }
 
+function disablepassword {
+  checkroot
+  passwd -l pi
+}
+
+function enablepassword {
+  checkroot
+  passwd -u pi
+}
+
 function password_help () {
   echo
   echo "Usage: $BASENAME password <password>"
+  echo "       $BASENAME password [disable|enable]"
   echo
   echo "Changes the password for 'pi' user"
   echo
   echo "Example:"
   echo "  $BASENAME password ABC"
   echo "      Sets the password for 'pi' user to 'ABC'."
-  echo
+  echo "  $BASENAME password disable"
+  echo "      Disables password authentication (only passphrase allowed)"
+  echo "  $BASENAME password enable"
+  echo "      Enables password authentication (password or passphrase allowed)"
 }

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -17,11 +17,13 @@ function password {
 function disablepassword {
   checkroot
   passwd -l pi
+  echo "Password disabled successfully"
 }
 
 function enablepassword {
   checkroot
   passwd -u pi
+  echo "Password enabled successfully"
 }
 
 function password_help () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.19.21",
+  "version": "1.19.29",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Fixes #540 

A simpler alternative to PR #1171 that modifies the `/etc/passwd` file by adding a `!` to the `pi` user
