### PR TITLE
`treehouses power` help on error (fixes #1180)

### DIFF
--- a/modules/power.sh
+++ b/modules/power.sh
@@ -44,10 +44,12 @@ function power {
       ;;
     "")
       echo "Error: please choose one of the 5 modes"
+      power_help
       exit 1
       ;;
     *)
       echo "Error: power '$mode' does not exist"
+      power_help
       exit 1
       ;;
   esac     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.19.21",
+  "version": "1.19.25",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Fixes #1180 

Help menu appears now when the user incorrectly uses `treehouses power`