### PR TITLE
`treehouses usb` help on error (fixes #1183)

### DIFF
--- a/modules/usb.sh
+++ b/modules/usb.sh
@@ -56,7 +56,8 @@ function usb {
     elif [ "$command" = "" ]; then
       lsusb -t
     else
-      echo "unknown command"
+      echo "Error: unknown command"
+      usb_help
     fi
   fi
 }

--- a/modules/usb.sh
+++ b/modules/usb.sh
@@ -58,6 +58,7 @@ function usb {
     else
       echo "Error: unknown command"
       usb_help
+      exit 1
     fi
   fi
 }

--- a/modules/usb.sh
+++ b/modules/usb.sh
@@ -22,8 +22,12 @@ function usb {
       /usr/local/bin/hub-ctrl -h 1 -P 2 -p
 
       echo "usb ports turned off"
+    elif [ "$command" = "" ]; then
+      lsusb -t
     else
-      echo "unknown command"
+      echo "Error: unknown command"
+      usb_help
+      exit 1
     fi
   elif [[ $(detectrpi) =~ 'RPI4' ]]; then
     if [ "$command" = "on" ]; then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.19.21",
+  "version": "1.19.28",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Fixes #1183 

Help menu appears now when the user incorrectly uses `treehouses usb on/off`