### PR TITLE
`treehouses usb` tab completion (fixes #1182)

### DIFF
--- a/_treehouses
+++ b/_treehouses
@@ -311,6 +311,7 @@ treehouses upgrade
 treehouses upgrade force
 treehouses upgrade bluetooth
 treehouses upgrade check
+treehouses usb
 treehouses usb off
 treehouses usb on
 treehouses verbose

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.19.21",
+  "version": "1.19.27",
   "remote": "2251",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Fixes #1182 

The `treehouses usb` command wasn't working as the command wasn't added to `_treehouses`.