### PR TITLE
`treehouses help bluetooth` spacing (fixes #1195)

### DIFF
--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -129,7 +129,7 @@ function bluetooth_help {
   echo "  $BASENAME bluetooth restart"
   echo "      This will restart the bluetooth server using $BASENAME bleutooth 'off' and 'on'"
   echo
-  echo "  $BASENAME bluetooth  mac"
+  echo "  $BASENAME bluetooth mac"
   echo "      This will display the bluetooth MAC address"
   echo
   echo "  $BASENAME bluetooth id"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.19.29",
+  "version": "1.19.30",
   "remote": "2346",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Fix spacing in the bluetooth_help function