### PR TITLE
`treehouses` stop spinner with ctrl+z (fixes #1289)

### DIFF
--- a/modules/globals.sh
+++ b/modules/globals.sh
@@ -213,7 +213,7 @@ function start_spinner() {
     return
   fi
   set -m
-  trap kill_spinner {0..15}
+  trap kill_spinner {0..15} 20
   spinner &
   SPINPID=$!
   disown

--- a/modules/globals.sh
+++ b/modules/globals.sh
@@ -213,7 +213,7 @@ function start_spinner() {
     return
   fi
   set -m
-  trap kill_spinner {0..15} 20
+  trap kill_spinner {0..15} SIGTSTP
   spinner &
   SPINPID=$!
   disown

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.20.32",
+  "version": "1.20.34",
   "remote": "2346",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
When hitting `ctrl+z` when running `treehouses heavymetal` it isn't trapped by the spinner. So the spinner will keep running even though the cli has been sent to the background. This fixes that. Trying ctrl+z before and after this PR shows the change. 
![](https://edge.alluremedia.com.au/m/l/2017/05/Fidget4.jpg)