### PR TITLE
`treehouses couchdb` more EOF (fixes #1293)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.20.32",
+  "version": "1.20.38",
   "remote": "2346",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",

--- a/services/install-couchdb.sh
+++ b/services/install-couchdb.sh
@@ -25,6 +25,7 @@ if [ "$couchdb_autorun" = true ]; then
   treehouses services couchdb up
 fi
 
+
 EOF
 }
 

--- a/services/install-couchdb.sh
+++ b/services/install-couchdb.sh
@@ -5,28 +5,27 @@ function install {
   mkdir -p /srv/couchdb
 
   # create yml(s)
-  {
-    echo "version: \"2\""
-    echo "services:"
-    echo "  couchdb:"
-    echo "    image: treehouses/couchdb:2.3.1"
-    echo "    ports:"
-    echo "      - \"5984:5984\""
-    echo "    volumes:"
-    echo "      - \"/srv/couchdb/data:/opt/couchdb/data\""
-    echo "      - \"/srv/couchdb/log:/opt/couchdb/var/log\""
-  } > /srv/couchdb/couchdb.yml
+  cat << EOF > /srv/couchdb/couchdb.yml
+version: "2"
+services:
+  couchdb:
+    image: treehouses/couchdb:2.3.1
+    ports:
+      - "5984:5984"
+    volumes:
+      - "/srv/couchdb/data:/opt/couchdb/data"
+      - "/srv/couchdb/log:/opt/couchdb/var/log"
+EOF
 
   # add autorun
-  {
-    echo "couchdb_autorun=true"
-    echo
-    echo "if [ \"\$couchdb_autorun\" = true ]; then"
-    echo "  treehouses services couchdb up"
-    echo "fi"
-    echo
-    echo
-  } > /srv/couchdb/autorun
+  cat << EOF > /srv/couchdb/autorun
+couchdb_autorun=true
+
+if [ "$couchdb_autorun" = true ]; then
+  treehouses services couchdb up
+fi
+
+EOF
 }
 
 # environment var


### PR DESCRIPTION
- [x] - test if works with changes and couchdb url visited. 

```bash
root@treehouses:~/cli# ./cli.sh services couchdb install
Pulling couchdb ... done
couchdb installed
root@treehouses:~/cli# ./cli.sh services couchdb up
Creating network "couchdb_default" with the default driver
Creating couchdb_couchdb_1 ... done
couchdb built and started
root@treehouses:~/cli# ./cli.sh services couchdb port
5984
root@treehouses:~/cli# ./cli.sh services couchdb url
192.168.0.23:5984/_utils
root@treehouses:~/cli# cd tests
root@treehouses:~/cli/tests# cd services/
root@treehouses:~/cli/tests/services# bats ./couchdb.bats
 ✓  services couchdb info
 ✓  services couchdb install
 ✓  services couchdb up
 ✓  services couchdb restart
 ✓  services available
 ✓  services running
 ✓  services running full
 ✓  services installed
 ✓  services installed full
 ✓  services ports
 ✓  services couchdb port
 ✓  services couchdb ps
 ✓  services couchdb url
 ✓  services couchdb autorun
 ✓  services couchdb autorun true
 ✓  services couchdb stop
 ✓  services couchdb start
 ✓  services couchdb down
 ✓  services couchdb icon
 ✓  services couchdb cleanup

20 tests, 0 failures
root@treehouses:~/cli/tests/services#
```