### PR TITLE
`treehouses changelog` new format (fixes #1304)

### DIFF
--- a/modules/changelog.sh
+++ b/modules/changelog.sh
@@ -31,11 +31,11 @@ case "$displaymode" in
         case "$version2" in
          "")
           checkargn $# 2
-          sed "/\[$CURRENT\]/!d;s//&\n/;s/.*\n//;:a;/\[$version1\]/bb;\$!{n;ba};:b;s//\n&/;P;D" $LOGPATH | tac #grabs text between version numbers, print bottom to top
+          sed "/### $CURRENT/!d;s//&\n/;s/.*\n//;:a;/### $version1/bb;\$!{n;ba};:b;s//\n&/;P;D" $LOGPATH | tac #grabs text between version numbers, print bottom to top
           ;;
         *)
           checkargn $# 3
-          sed "/\[$version2\]/!d;s//&\n/;s/.*\n//;:a;/\[$version1\]/bb;\$!{n;ba};:b;s//\n&/;P;D" $LOGPATH | tac
+          sed "/### $version2/!d;s//&\n/;s/.*\n//;:a;/### $version1/bb;\$!{n;ba};:b;s//\n&/;P;D" $LOGPATH | tac
           ;;
         esac
         ;;

--- a/modules/changelog.sh
+++ b/modules/changelog.sh
@@ -19,7 +19,7 @@ case "$displaymode" in
       ;;
   "")
       checkargn $# 0
-      sed '3d;4d;5d;' $LOGPATH | tac #filters out auto generate message and prints bottom to top
+      tac $LOGPATH
      ;;
   compare)
       case "$version1" in

--- a/modules/changelog.sh
+++ b/modules/changelog.sh
@@ -19,7 +19,7 @@ case "$displaymode" in
       ;;
   "")
       checkargn $# 0
-      tac $LOGPATH
+      cat $LOGPATH
      ;;
   compare)
       case "$version1" in
@@ -31,11 +31,11 @@ case "$displaymode" in
         case "$version2" in
          "")
           checkargn $# 2
-          sed "/^### $CURRENT/!d;s//&\n/;s/.*\n//;:a;/^### $version1/bb;\$!{n;ba};:b;s//\n&/;P;D" $LOGPATH | tac #grabs text between version numbers, print bottom to top
+          sed "/^### $CURRENT/!d;s//&\n/;s/.*\n//;:a;/^### $version1/bb;\$!{n;ba};:b;s//\n&/;P;D" $LOGPATH #grabs text between version numbers, print bottom to top
           ;;
         *)
           checkargn $# 3
-          sed "/^### $version2/!d;s//&\n/;s/.*\n//;:a;/^### $version1/bb;\$!{n;ba};:b;s//\n&/;P;D" $LOGPATH | tac
+          sed "/^### $version2/!d;s//&\n/;s/.*\n//;:a;/^### $version1/bb;\$!{n;ba};:b;s//\n&/;P;D" $LOGPATH
           ;;
         esac
         ;;

--- a/modules/changelog.sh
+++ b/modules/changelog.sh
@@ -31,11 +31,11 @@ case "$displaymode" in
         case "$version2" in
          "")
           checkargn $# 2
-          sed "/### $CURRENT/!d;s//&\n/;s/.*\n//;:a;/### $version1/bb;\$!{n;ba};:b;s//\n&/;P;D" $LOGPATH | tac #grabs text between version numbers, print bottom to top
+          sed "/^### $CURRENT/!d;s//&\n/;s/.*\n//;:a;/^### $version1/bb;\$!{n;ba};:b;s//\n&/;P;D" $LOGPATH | tac #grabs text between version numbers, print bottom to top
           ;;
         *)
           checkargn $# 3
-          sed "/### $version2/!d;s//&\n/;s/.*\n//;:a;/### $version1/bb;\$!{n;ba};:b;s//\n&/;P;D" $LOGPATH | tac
+          sed "/^### $version2/!d;s//&\n/;s/.*\n//;:a;/^### $version1/bb;\$!{n;ba};:b;s//\n&/;P;D" $LOGPATH | tac
           ;;
         esac
         ;;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.20.35",
+  "version": "1.21.2",
   "remote": "2346",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
update `treehouses changelog compare` to work with new `CHANGELOG.md` format

fixes #1304 