### PR TITLE
`treehouses services mongodb` port 28017 (fixes #1314)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.20.35",
+  "version": "1.20.36",
   "remote": "2346",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",

--- a/services/install-mongodb.sh
+++ b/services/install-mongodb.sh
@@ -16,6 +16,7 @@ function install {
     echo "      -  \"27017:27017"\"
     echo "      -  \"27018:27018"\"
     echo "      -  \"27019:27019"\"
+    echo "      -  \"28017:28017"\"
     echo "    environment: "
     echo "      - MONGO_INITDB_ROOT_USERNAME=\${MONGO_INITDB_ROOT_USERNAME_VAR}"
     echo "      - MONGO_INITDB_ROOT_PASSWORD=\${MONGO_INITDB_ROOT_PASSWORD_VAR}"
@@ -55,6 +56,7 @@ function get_ports {
   echo "27017"
   echo "27018"
   echo "27019"
+  echo "28017"
 }
 
 # add size (in MB)


### PR DESCRIPTION
Add port 28017 for the default MongoDB web interface
![image](https://user-images.githubusercontent.com/44413241/82519241-cf579300-9ae6-11ea-9652-f0e061e3e5e2.png)
