### PR TITLE
update `package.json` (fixes #1323)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.21.3",
+  "version": "1.21.4",
   "remote": "2346",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/treehouses/cli.git"
   },
   "scripts": {
-    "postinstall": "if [ $(id -u) = 0 ]; then ln -sr _treehouses /etc/bash_completion.d/_treehouses; fi && exit 0",
+    "postinstall": "if [ $(id -u) = 0 ]; then ln -srf _treehouses /etc/bash_completion.d/_treehouses; fi && exit 0",
     "postuninstall": "if [ $(id -u) = 0 ]; then rm /etc/bash_completion.d/_treehouses; if [ -f /etc/treehouses.conf ]; then rm /etc/treehouses.conf; fi fi && exit 0",
     "test": "echo \"Error: no test specified\" && exit 0"
   },


### PR DESCRIPTION
add -f to ln in postinstall

fixes #1323

- last major vagrant issue
- vagrant can now build images without problems