### PR TITLE
`treehouses services calibre-web` (fixes #1218)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ services                                  executes the given command on the spec
    [minetest]                             Minetest is an open source infinite-world block sandbox game engine with survival and crafting
    [invoiceninja]                         Invoiceninja is the leading self-host platform to create invoices.
    [librespeed]                           Librespeed is a very lightweight Speedtest implemented in Javascript
+   [calibre-web]                          Calibre-web is a web app providing a clean interface for browsing, reading, and downloading eBooks.
 tor [list|add|delete|deleteall|start]     deals with services on tor hidden network
     [stop|destroy|notice|status|refresh]
 bootoption <console|desktop> [autologin]  sets the boot mode

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -83,6 +83,7 @@ services                                  executes the given command on the spec
    [musicblocks]                          MusicBlocks is a programming language for exploring musical concepts in an fun way
    [minetest]                             Minetest is an open source infinite-world block sandbox game engine with survival and crafting
    [invoiceninja]                         Invoiceninja is the leading self-host platform to create invoices.
+   [calibre-web]                          Calibre-web is a web app providing a clean interface for browsing, reading, and downloading eBooks. 
 tor [list|add|delete|deleteall|start]     deals with services on tor hidden network
     [stop|destroy|notice|status|refresh]
 bootoption <console|desktop> [autologin]  sets the boot mode

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -624,6 +624,7 @@ function services_help {
   echo "  musicblocks     Music Blocks is a programming language and collection of manipulative tools for exploring musical and mathematical concepts in an integrative and fun way." 
   echo "  minetest        Minetest is an open source infinite-world block sandbox game engine with survival and crafting"
   echo "  invoiceninja    Invoiceninja is the leading self-host platform to create invoices."
+  echo "  calibre-web     Calibre-web is a web app providing a clean interface for browsing, reading, and downloading eBooks."
   echo
   echo
   echo "Top-Level Commands:"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ssh", "sshkey", "sshtunnel", "tor", "openvpn", "coral", "iot",
     "services", "container", "docker", "balena", "pihole", "turtleblocks", "musicblocks",
     "kolibri", "mongodb", "moodle", "netdata", "nextcloud", "ntopng", "planet", "invoiceninja", "librespeed",
-    "portainer", "privatebin", "mastodon", "couchdb", "mariadb", "seafile", "minetest"
+    "portainer", "privatebin", "mastodon", "couchdb", "mariadb", "seafile", "minetest", "calibre-web"
   ],
   "author": {
     "name": "OLE treehouses team",

--- a/services/install-calibre-web.sh
+++ b/services/install-calibre-web.sh
@@ -19,7 +19,7 @@ services:
       - "/srv/calibre-web.sh:/root/.calibre-web"
       - "/srv/calibre-web.sh:/books"
     ports:
-      - 8090:8090
+      - 8090:80
     restart: unless-stopped
 EOF
 
@@ -79,8 +79,27 @@ function get_info {
 }
 
 # add svg icon
-# function get_icon {
-#   cat <<EOF
-
-# EOF
-# }
+function get_icon {
+  cat <<EOF
+    <?xml version="1.0" standalone="no"?>
+    <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
+    "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+    <svg version="1.0" xmlns="http://www.w3.org/2000/svg"
+    width="256.000000pt" height="256.000000pt" viewBox="0 0 256.000000 256.000000"
+    preserveAspectRatio="xMidYMid meet">
+    <metadata>
+    Created by potrace 1.16, written by Peter Selinger 2001-2019
+    </metadata>
+    <g transform="translate(0.000000,256.000000) scale(0.100000,-0.100000)"
+    fill="#000000" stroke="none">
+    <path d="M1035 2540 c-260 -52 -473 -166 -661 -354 -191 -191 -314 -425 -359
+    -680 -20 -115 -20 -337 0 -452 45 -255 168 -489 359 -680 250 -250 551 -374
+    906 -374 355 0 656 124 906 374 191 191 314 425 359 680 20 115 20 337 0 452
+    -45 255 -168 489 -359 680 -191 190 -404 304 -668 355 -130 25 -356 25 -483
+    -1z m789 -516 c13 -12 16 -40 16 -140 l0 -124 28 0 c15 0 33 -5 40 -12 17 -17
+    17 -1199 0 -1216 -16 -16 -1064 -17 -1123 -1 -52 15 -119 82 -134 134 -16 57
+    -15 1193 1 1247 13 45 64 98 110 114 24 9 173 13 540 13 448 1 508 -1 522 -15z"/>
+    </g>
+    </svg>
+EOF
+}

--- a/services/install-calibre-web.sh
+++ b/services/install-calibre-web.sh
@@ -17,7 +17,7 @@ services:
       - DOCKER_MODS=linuxserver/calibre-web:calibre
     volumes:
       - "/srv/calibre-web.sh:/root/.calibre-web"
-      - "/srv/calibre-web.sh:/books
+      - "/srv/calibre-web.sh:/books"
     ports:
       - 8090:8090
     restart: unless-stopped

--- a/services/install-calibre-web.sh
+++ b/services/install-calibre-web.sh
@@ -17,7 +17,6 @@ services:
       - DOCKER_MODS=linuxserver/calibre-web:calibre
     volumes:
       - "/srv/calibre-web.sh:/root/.calibre-web"
-      - "/srv/calibre-web.sh:/books"
     ports:
       - 8090:80
     restart: unless-stopped

--- a/services/install-calibre-web.sh
+++ b/services/install-calibre-web.sh
@@ -19,7 +19,7 @@ services:
       - "/srv/calibre-web.sh:/root/.calibre-web"
       - "/srv/calibre-web.sh:/books"
     ports:
-      - 8090:80
+      - 8090:8083
     restart: unless-stopped
 EOF
 

--- a/services/install-calibre-web.sh
+++ b/services/install-calibre-web.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+function install {
+  # create service directory
+  mkdir -p /srv/calibre-web
+
+  # create yml(s)
+  cat << EOF > /srv/calibre-web/calibre-web.yml
+version: "2.1"
+services:
+  calibre-web:
+    image: linuxserver/calibre-web
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+      - DOCKER_MODS=linuxserver/calibre-web:calibre
+    volumes:
+      - "/srv/calibre-web.sh:/root/.calibre-web.sh"
+      - path to calibre library:/books
+    ports:
+      - 8090:8090
+    restart: unless-stopped
+EOF
+
+  # create .env with default values
+  cat << EOF > /srv/calibre-web/.env
+PUID=1000
+PGID=1000
+TZ=Europe/London
+PASSWORD=PASSWORD
+DB_TYPE=sqlite
+DB_NAME=DB_NAME
+DB_HOSTNAME=DB_HOSTNAME
+DB_USERNAME=DB_USERNAME
+DB_PASSWORD=DB_PASSWORD
+EOF
+
+  # add autorun
+  cat << EOF > /srv/calibre-web/autorun
+calibre-web_autorun=true
+
+if [ "$calibre-web_autorun" = true ]; then
+  treehouses services librespeed up
+fi
+
+
+EOF
+}
+
+# environment var
+function uses_env {
+  echo true
+}
+
+# add supported arm(s)
+function supported_arms {
+  echo "v7l"
+}
+
+# add port(s)
+function get_ports {
+  echo "8090"
+}
+
+# add size (in MB)
+function get_size {
+  echo "60"
+}
+
+# add info
+function get_info {
+  echo "https://github.com/linuxserver/docker-calibre-web"
+  echo
+  echo "Calibre-web is a web app providing a clean interface for "
+  echo "browsing, reading and downloading eBooks using an existing Calibre database." 
+  echo "It is also possible to integrate google drive and edit metadata and"
+  echo "your calibre library through the app itself."
+}
+
+# add svg icon
+# function get_icon {
+#   cat <<EOF
+
+# EOF
+}

--- a/services/install-calibre-web.sh
+++ b/services/install-calibre-web.sh
@@ -83,4 +83,4 @@ function get_info {
 #   cat <<EOF
 
 # EOF
-}
+# }

--- a/services/install-calibre-web.sh
+++ b/services/install-calibre-web.sh
@@ -17,7 +17,7 @@ services:
       - DOCKER_MODS=linuxserver/calibre-web:calibre
     volumes:
       - "/srv/calibre-web.sh:/root/.calibre-web"
-      - "/srv/calibre-web.sh:/books"
+      - path to calibre library:/books
     ports:
       - 8083:8083
     restart: unless-stopped

--- a/services/install-calibre-web.sh
+++ b/services/install-calibre-web.sh
@@ -17,6 +17,7 @@ services:
       - DOCKER_MODS=linuxserver/calibre-web:calibre
     volumes:
       - "/srv/calibre-web.sh:/root/.calibre-web"
+      - "/srv/calibre-web.sh:/books"
     ports:
       - 8090:80
     restart: unless-stopped

--- a/services/install-calibre-web.sh
+++ b/services/install-calibre-web.sh
@@ -16,7 +16,7 @@ services:
       - TZ=${TZ}
       - DOCKER_MODS=linuxserver/calibre-web:calibre
     volumes:
-      - "/srv/calibre-web.sh:/root/.calibre-web"
+      - path to data:/config
       - path to calibre library:/books
     ports:
       - 8083:8083

--- a/services/install-calibre-web.sh
+++ b/services/install-calibre-web.sh
@@ -19,7 +19,7 @@ services:
       - "/srv/calibre-web.sh:/root/.calibre-web"
       - "/srv/calibre-web.sh:/books"
     ports:
-      - 8090:8083
+      - 8083:8083
     restart: unless-stopped
 EOF
 
@@ -60,7 +60,7 @@ function supported_arms {
 
 # add port(s)
 function get_ports {
-  echo "8090"
+  echo "8083"
 }
 
 # add size (in MB)

--- a/services/install-calibre-web.sh
+++ b/services/install-calibre-web.sh
@@ -16,8 +16,8 @@ services:
       - TZ=${TZ}
       - DOCKER_MODS=linuxserver/calibre-web:calibre
     volumes:
-      - "/srv/calibre-web.sh:/root/.calibre-web.sh"
-      - path to calibre library:/books
+      - "/srv/calibre-web.sh:/root/.calibre-web"
+      - "/srv/calibre-web.sh:/books
     ports:
       - 8090:8090
     restart: unless-stopped

--- a/services/install-calibre-web.sh
+++ b/services/install-calibre-web.sh
@@ -41,7 +41,7 @@ EOF
 calibre-web_autorun=true
 
 if [ "$calibre-web_autorun" = true ]; then
-  treehouses services librespeed up
+  treehouses services calibre-web up
 fi
 
 

--- a/services/install-calibre-web.sh
+++ b/services/install-calibre-web.sh
@@ -16,8 +16,8 @@ services:
       - TZ=${TZ}
       - DOCKER_MODS=linuxserver/calibre-web:calibre
     volumes:
-      - path to data:/config
-      - path to calibre library:/books
+      - "/srv/calibre-web:/root/.calibre-web"
+      - "/srv/books:/books"
     ports:
       - 8083:8083
     restart: unless-stopped

--- a/services/install-calibre.sh
+++ b/services/install-calibre.sh
@@ -5,7 +5,7 @@ function install {
   mkdir -p /srv/calibre
 
   # create yml(s)
-  cat << EOF > /srv/calibre-web/calibre.yml
+  cat << EOF > /srv/calibre/calibre.yml
 version: "2.1"
 services:
   calibre:

--- a/services/install-calibre.sh
+++ b/services/install-calibre.sh
@@ -23,7 +23,7 @@ services:
 EOF
 
   # create .env with default values
-  cat << EOF > /srv/calibre/.env
+  cat << EOF > /srv/calibre/calibre.env
 PUID=1000
 PGID=1000
 TZ=Europe/London

--- a/services/install-calibre.sh
+++ b/services/install-calibre.sh
@@ -2,29 +2,28 @@
 
 function install {
   # create service directory
-  mkdir -p /srv/calibre-web
+  mkdir -p /srv/calibre
 
   # create yml(s)
-  cat << EOF > /srv/calibre-web/calibre-web.yml
+  cat << EOF > /srv/calibre-web/calibre.yml
 version: "2.1"
 services:
-  calibre-web:
-    image: linuxserver/calibre-web
+  calibre:
+    image: linuxserver/calibre
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - DOCKER_MODS=linuxserver/calibre-web:calibre
     volumes:
-      - "/srv/calibre-web:/root/.calibre-web"
-      - "/srv/calibre-web:/books:/books"
+      - "/srv/calibre:/root/.calibre"
     ports:
-      - 8083:8083
+      - 8080:8080
+      - 8081:8081
     restart: unless-stopped
 EOF
 
   # create .env with default values
-  cat << EOF > /srv/calibre-web/.env
+  cat << EOF > /srv/calibre/.env
 PUID=1000
 PGID=1000
 TZ=Europe/London
@@ -37,11 +36,11 @@ DB_PASSWORD=DB_PASSWORD
 EOF
 
   # add autorun
-  cat << EOF > /srv/calibre-web/autorun
-calibre-web_autorun=true
+  cat << EOF > /srv/calibre/autorun
+calibre_autorun=true
 
-if [ "$calibre-web_autorun" = true ]; then
-  treehouses services calibre-web up
+if [ "$calibre_autorun" = true ]; then
+  treehouses services calibre up
 fi
 
 
@@ -60,7 +59,8 @@ function supported_arms {
 
 # add port(s)
 function get_ports {
-  echo "8083"
+  echo "8080"
+  echo "8081"
 }
 
 # add size (in MB)
@@ -70,12 +70,10 @@ function get_size {
 
 # add info
 function get_info {
-  echo "https://github.com/linuxserver/docker-calibre-web"
-  echo
-  echo "Calibre-web is a web app providing a clean interface for "
-  echo "browsing, reading and downloading eBooks using an existing Calibre database." 
-  echo "It is also possible to integrate google drive and edit metadata and"
-  echo "your calibre library through the app itself."
+  echo "https://github.com/linuxserver/docker-calibre"
+  echo "Calibre is a powerful and easy to use e-book manager."
+  echo "It’ll allow you to do nearly everything and it takes" 
+  echo "things a step beyond normal e-book software." 
 }
 
 # add svg icon

--- a/tests/services/calibre-web.bats
+++ b/tests/services/calibre-web.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+load ../test-helper
+
+@test "$clinom services calibre-web info" {
+  run "${clicmd}" services calibre-web info
+  assert_success && assert_output -p 'https://github.com/librespeed/speedtest'
+}
+
+@test "$clinom services calibre-web install" {
+  run "${clicmd}" services calibre-web install
+  assert_success && assert_output -p 'installed'
+}
+
+@test "$clinom services calibre-web up" {
+  run "${clicmd}" services calibre-web up
+  sleep 5
+  assert_success && assert_output -p 'calibre-web built and started'
+}
+
+@test "$clinom services calibre-web start" {
+  run "${clicmd}" services calibre-web start
+  sleep 5
+  assert_success && assert_output -p 'calibre-web started'
+}
+
+@test "$clinom services calibre-web restart" {
+  run "${clicmd}" services calibre-web restart
+  sleep 5
+  assert_success && assert_output -p 'calibre-web built and started'
+}
+
+@test "$clinom services available" {
+  run "${clicmd}" services available
+  assert_success && assert_output -p 'calibre-web'
+}
+
+@test "$clinom services running" {
+  run "${clicmd}" services running
+  assert_success && assert_output -p 'calibre-web'
+}
+
+@test "$clinom services running full" {
+  run "${clicmd}" services running full
+  assert_success && assert_output -p 'linuxserver/calibre-web'
+}
+
+@test "$clinom services installed" {
+  run "${clicmd}" services installed
+  assert_success && assert_output -p 'calibre-web'
+}
+
+@test "$clinom services installed full" {
+  run "${clicmd}" services installed full
+  assert_success && assert_output -p 'linuxserver/calibre-web'
+}
+
+@test "$clinom services ports" {
+  run "${clicmd}" services ports
+  assert_success && assert_output -p 'port 80'
+}
+
+@test "$clinom services calibre-web port" {
+  run "${clicmd}" services calibre-web port
+  assert_success && assert_output -p '8090'
+}
+
+@test "$clinom services calibre-web ps" {
+  run "${clicmd}" services calibre-web ps
+  assert_success && assert_output -p 'linuxserver/calibre-web'
+}
+
+@test "$clinom services calibre-web url" {
+  run "${clicmd}" services calibre-web url
+  assert_output -p '80'
+}
+
+@test "$clinom services calibre-web autorun" {
+  run "${clicmd}" services calibre-web autorun
+  assert_success
+}
+
+@test "$clinom services calibre-web autorun true" {
+  run "${clicmd}" services calibre-web autorun true
+  assert_success && assert_output -p 'set to true'
+}
+
+@test "$clinom services calibre-web stop" {
+  run "${clicmd}" services calibre-web stop
+  assert_success && assert_output -p 'calibre-web stopped'
+}
+
+@test "$clinom services calibre-web down" {
+  run "${clicmd}" services calibre-web down
+  assert_success && assert_output -p 'calibre-web stopped and removed'
+}
+
+@test "$clinom services calibre-web icon" {
+  run "${clicmd}" services calibre-web icon
+  assert_success && assert_output -p 'svg'
+}
+
+@test "$clinom services calibre-web cleanup" {
+  run "${clicmd}" services calibre-web cleanup
+  assert_success && assert_output -p 'cleaned up'
+}

--- a/tests/services/calibre-web.bats
+++ b/tests/services/calibre-web.bats
@@ -3,7 +3,7 @@ load ../test-helper
 
 @test "$clinom services calibre-web info" {
   run "${clicmd}" services calibre-web info
-  assert_success && assert_output -p 'https://github.com/librespeed/speedtest'
+  assert_success && assert_output -p 'https://github.com/linuxserver/docker-calibre-web'
 }
 
 @test "$clinom services calibre-web install" {


### PR DESCRIPTION
Fixes #1218 

```
root@treehouses:~/cli# ./cli.sh services calibre-web install
Pulling calibre-web ... done
calibre-web installed
modify default environment variables by running 'cli.sh services calibre-web config edit'
root@treehouses:~/cli# ./cli.sh services calibre-web start
Starting calibre-web ... done
calibre-web started
root@treehouses:~/cli# ./cli.sh services calibre-web url
192.168.1.15:8090
```

All tests worked for me as well.