### PR TITLE
`treehouses camera detect` (fixes #1315)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ coralenv [install|demo-on|demo-off]       plays with the coral environmental boa
 memory [total|used|free]                  displays the total memory of the device, the memory used as well as the available free memory
 temperature [celsius|fahrenheit|kelvin]   displays raspberry pi's CPU temperature
 speedtest                                 tests internet download and upload speed
-camera [on|off|capture]                   enables camera, disables camera, captures png photo
+camera [on|off|capture|detect]                   enables camera, disables camera, captures png photo, detects camera module version
 cron [list|add|delete|deleteall]          adds, deletes a custom cron job or deletes, lists all cron jobs
      [0W|tor|timestamp]                   adds premade cron job (or removes it if already active)
 usb [on|off]                              turns usb ports on or off

--- a/_treehouses
+++ b/_treehouses
@@ -42,6 +42,7 @@ treehouses camera
 treehouses camera capture
 treehouses camera off
 treehouses camera on
+treehouses camera detect
 treehouses changelog
 treehouses changelog view
 treehouses changelog compare

--- a/modules/camera.sh
+++ b/modules/camera.sh
@@ -65,13 +65,13 @@ function camera {
         echo "Camera is plugged in."
         if file ${directory}$BASENAME-${timestamp}.png | grep -q "2592 x 1944" ; then
           echo "Camera Module v1 detected."
-          rm file ${directory}$BASENAME-${timestamp}.png
+          rm ${directory}$BASENAME-${timestamp}.png
         elif file ${directory}$BASENAME-${timestamp}.png | grep -q "3280 × 2464" ; then
           echo "Camera Module v2 detected."
-          rm file ${directory}$BASENAME-${timestamp}.png
+          rm ${directory}$BASENAME-${timestamp}.png
         elif file ${directory}$BASENAME-${timestamp}.png | grep -q "4056 x 3040" ; then
           echo "HQ Camera detected."
-          rm file ${directory}$BASENAME-${timestamp}.png
+          rm ${directory}$BASENAME-${timestamp}.png
         else
           echo "Unknown Camera detected. Something went wrong!"
         fi

--- a/modules/camera.sh
+++ b/modules/camera.sh
@@ -65,10 +65,13 @@ function camera {
         echo "Camera is plugged in."
         if file ${directory}$BASENAME-${timestamp}.png | grep -q "2592 x 1944" ; then
           echo "Camera Module v1 detected."
+          rm file ${directory}$BASENAME-${timestamp}.png
         elif file ${directory}$BASENAME-${timestamp}.png | grep -q "3280 × 2464" ; then
           echo "Camera Module v2 detected."
+          rm file ${directory}$BASENAME-${timestamp}.png
         elif file ${directory}$BASENAME-${timestamp}.png | grep -q "4056 x 3040" ; then
           echo "HQ Camera detected."
+          rm file ${directory}$BASENAME-${timestamp}.png
         else
           echo "Unknown Camera detected. Something went wrong!"
         fi

--- a/modules/camera.sh
+++ b/modules/camera.sh
@@ -103,4 +103,8 @@ function camera_help {
   echo "    $BASENAME camera capture"
   echo "      Camera is capturing and storing a time-stamped photo in ${directory}."
   echo
+  echo "    $BASENAME camera detect"
+  echo "      Camera is plugged in."
+  echo "      Camera Module v1 detected."
+  echo
 }

--- a/modules/camera.sh
+++ b/modules/camera.sh
@@ -64,7 +64,13 @@ function camera {
       else
         echo "Camera is plugged in."
         if file ${directory}$BASENAME-${timestamp}.png | grep -q "2592 x 1944" ; then
-          echo "Model 1 detected."
+          echo "Camera Module v1 detected."
+        elif file ${directory}$BASENAME-${timestamp}.png | grep -q "3280 × 2464" ; then
+          echo "Camera Module v2 detected."
+        elif file ${directory}$BASENAME-${timestamp}.png | grep -q "4056 x 3040" ; then
+          echo "HQ Camera detected."
+        else
+          echo "Unknown Camera detected. Something went wrong!"
         fi
       fi
     fi

--- a/modules/camera.sh
+++ b/modules/camera.sh
@@ -53,6 +53,23 @@ function camera {
       fi
     ;;
 
+    "detect")
+    mkdir -p ${directory}
+    if ! grep -q "start_x=1" ${config} ; then
+      echo "You need to enable AND reboot first in order to take pictures."
+      exit 1
+    else
+      if camera capture |& grep -q "mmal: main:" ; then
+        echo "Camera is not plugged in."
+      else
+        echo "Camera is plugged in."
+        if file ${directory}$BASENAME-${timestamp}.png | grep -q "2592 x 1944" ; then
+          echo "Model 1 detected."
+        fi
+      fi
+    fi
+    ;;
+
     "*")
       camera_help
     ;;

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -94,7 +94,7 @@ coralenv [install|demo-on|demo-off]       plays with the coral environmental boa
 memory [total|used|free]                  displays the total memory of the device, the memory used as well as the available free memory
 temperature [celsius|fahrenheit|kelvin]   displays raspberry pi's CPU temperature
 speedtest                                 tests internet download and upload speed
-camera [on|off|capture]                   enables camera, disables camera, captures png photo
+camera [on|off|capture|detect]                   enables camera, disables camera, captures png photo, detects camera module
 cron [list|add|delete|deleteall]          adds, deletes a custom cron job or deletes, lists all cron jobs
      [0W|tor|timestamp]                   adds premade cron job (or removes it if already active)
 usb [on|off]                              turns usb ports on or off

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.21.8",
+  "version": "1.21.16",
   "remote": "2346",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
allows the user to detect if there is a camera plugged in, and what version of the camera it is.

- needs testing for HQ camera and camera v2
- IR camera is v2
- nothing added to test.bats

fixes #1315