### PR TITLE
`treehouses services invoiceninja port` 8090 (fixes #1339)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.21.8",
+  "version": "1.21.14",
   "remote": "2346",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",

--- a/services/install-invoiceninja.sh
+++ b/services/install-invoiceninja.sh
@@ -54,7 +54,7 @@ function install {
     echo "    depends_on:"
     echo "      - app"
     echo "    ports: # Delete if you want to use reverse proxy"
-    echo "      - 8089:80"
+    echo "      - 8090:80"
     echo "    networks:"
     echo "#      - web        # uncomment if you want to use  external network (reverse proxy for example)"
     echo "      - default"
@@ -178,7 +178,7 @@ function supported_arms {
 
 # add port(s)
 function get_ports {
-  echo "8089"
+  echo "8090"
 }
 
 # add size (in MB)


### PR DESCRIPTION
Fixes #1339 
```
Pulling db   ... done
Pulling app  ... done
Pulling web  ... done
Pulling cron ... done
invoiceninja installed
modify default environment variables by running 'cli.sh services invoiceninja config edit'
root@treehouses:~/cli# ./cli.sh services invoiceninja up
valid yml
Creating network "invoiceninja_default" with the default driver
Creating volume "invoiceninja_db" with default driver
Creating volume "invoiceninja_storage" with default driver
Creating volume "invoiceninja_logo" with default driver
Creating volume "invoiceninja_public" with default driver
Creating invoiceninja_cron_1 ... done
Creating invoiceninja_db_1   ... done
Creating invoiceninja_app_1  ... done
Creating invoiceninja_web_1  ... done
invoiceninja built and started
root@treehouses:~/cli# ./cli.sh services invoiceninja url
:8090
```
Works for me.

![image](https://user-images.githubusercontent.com/35390215/83092412-3e933100-a06b-11ea-8dff-bed60b6dbe53.png)

After logging in:
![image](https://user-images.githubusercontent.com/35390215/83092436-4a7ef300-a06b-11ea-8e3a-94e433771acc.png)

