### PR TITLE
`treehouses camera on` & `off` refactor (fixes #1300)

### DIFF
--- a/modules/camera.sh
+++ b/modules/camera.sh
@@ -19,10 +19,8 @@ function camera {
 
     "on")
       if ! grep -q "start_x=1" ${config} ; then
-        cat ${config} > ${configtemp}
-        echo "start_x=1" >> ${configtemp}
-        cat ${configtemp} > ${config}
-        echo "Camera settings have been enabled. A reboot is needed in order to use the camera."
+        raspi-config nonint do_camera 0
+        echo "Camera settings have been enabled."
       elif grep -q "start_x=1" ${config} ; then
         echo "Camera is already enabled. Use \"$BASENAME camera capture\" to take a photo."
         echo "If you are having issues using the camera, try rebooting."
@@ -33,8 +31,8 @@ function camera {
 
     "off")
       if grep -q "start_x=1" ${config} ; then
-        sed -i '/start_x=1/d' ${config}
-        echo "Camera has been disabled. Reboot needed for settings to take effect."
+        raspi-config nonint do_camera 1
+        echo "Camera has been disabled."
       elif ! grep -q "start_x=1" ${config} ; then
         echo "Camera is already disabled. If camera is still enabled, try rebooting."
       else

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.21.16",
+  "version": "1.21.20",
   "remote": "2346",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
no longer needs reboot to enable and disable the camera

- fixes #1300