### PR TITLE
Camera reboot (fixes  #1396)

### DIFF
--- a/modules/camera.sh
+++ b/modules/camera.sh
@@ -24,6 +24,7 @@ function camera {
       if ! grep -q "start_x=1" ${config} ; then
         raspi-config nonint do_camera 0
         echo "Camera settings have been enabled. A reboot is needed in order to use the camera."
+        command reboot_needed
       elif grep -q "start_x=1" ${config} ; then
         echo "Camera is already enabled. Use \"$BASENAME camera capture\" to take a photo."
         echo "If you are having issues using the camera, try rebooting."
@@ -36,6 +37,7 @@ function camera {
       if grep -q "start_x=1" ${config} ; then
         raspi-config nonint do_camera 1
         echo "Camera has been disabled. A reboot is needed in order to use the camera."
+        command reboot_needed
       elif ! grep -q "start_x=1" ${config} ; then
         echo "Camera is already disabled. If camera is still enabled, try rebooting."
       else

--- a/modules/camera.sh
+++ b/modules/camera.sh
@@ -23,7 +23,7 @@ function camera {
     "on")
       if ! grep -q "start_x=1" ${config} ; then
         raspi-config nonint do_camera 0
-        echo "Camera settings have been enabled."
+        echo "Camera settings have been enabled. A reboot is needed in order to use the camera."
       elif grep -q "start_x=1" ${config} ; then
         echo "Camera is already enabled. Use \"$BASENAME camera capture\" to take a photo."
         echo "If you are having issues using the camera, try rebooting."
@@ -35,7 +35,7 @@ function camera {
     "off")
       if grep -q "start_x=1" ${config} ; then
         raspi-config nonint do_camera 1
-        echo "Camera has been disabled."
+        echo "Camera has been disabled. A reboot is needed in order to use the camera."
       elif ! grep -q "start_x=1" ${config} ; then
         echo "Camera is already disabled. If camera is still enabled, try rebooting."
       else


### PR DESCRIPTION
- reverts previous change removing the reboot notifications aka revolutionize
- enables reboot_needed after camera changes are made

fixes #1396