### PR TITLE
`treehouse services bookstack` (fixes #1340)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ services                                  executes the given command on the spec
    [minetest]                             Minetest is an open source infinite-world block sandbox game engine with survival and crafting
    [invoiceninja]                         Invoiceninja is the leading self-host platform to create invoices.
    [librespeed]                           Librespeed is a very lightweight Speedtest implemented in Javascript
+   [bookstack]                            Bookstack is a free and open source Wiki designed for creating beautiful documentation
    [grocy]                                grocy is a web-based, self-hosted groceries and household management utility for your home
 tor [list|add|delete|deleteall|start]     deals with services on tor hidden network
     [stop|destroy|notice|status|refresh]

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -83,6 +83,7 @@ services                                  executes the given command on the spec
    [musicblocks]                          MusicBlocks is a programming language for exploring musical concepts in an fun way
    [minetest]                             Minetest is an open source infinite-world block sandbox game engine with survival and crafting
    [invoiceninja]                         Invoiceninja is the leading self-host platform to create invoices.
+   [bookstack]                            Bookstack is a free and open source Wiki designed for creating beautiful documentation
    [grocy]                                grocy is a web-based, self-hosted groceries and household management utility for your home
 tor [list|add|delete|deleteall|start]     deals with services on tor hidden network
     [stop|destroy|notice|status|refresh]

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -624,6 +624,7 @@ function services_help {
   echo "  musicblocks     Music Blocks is a programming language and collection of manipulative tools for exploring musical and mathematical concepts in an integrative and fun way." 
   echo "  minetest        Minetest is an open source infinite-world block sandbox game engine with survival and crafting"
   echo "  invoiceninja    Invoiceninja is the leading self-host platform to create invoices."
+  echo "  bookstack       Bookstack is a free and open source Wiki designed for creating beautiful documentation"
   echo "  grocy           grocy is web-based, self-hosted groceries and household management utility for your home"
   echo
   echo

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bluetooth", "ethernet", "wifi", "hotspot", "bridge", "vnc",
     "ntp", "timezone", "rtc", "cron", "backup", "clone",
     "ssh", "sshkey", "sshtunnel", "tor", "openvpn", "coral", "iot",
-    "services", "container", "docker", "balena", "pihole", "turtleblocks", "musicblocks", "grocy",
+    "services", "container", "docker", "balena", "pihole", "turtleblocks", "musicblocks", "grocy", "bookstack",
     "kolibri", "mongodb", "moodle", "netdata", "nextcloud", "ntopng", "planet", "invoiceninja", "librespeed",
     "portainer", "privatebin", "mastodon", "couchdb", "mariadb", "seafile", "minetest"
   ],

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "bluetooth", "ethernet", "wifi", "hotspot", "bridge", "vnc",
     "ntp", "timezone", "rtc", "cron", "backup", "clone",
     "ssh", "sshkey", "sshtunnel", "tor", "openvpn", "coral", "iot",
-    "services", "container", "docker", "balena", "pihole", "turtleblocks", "musicblocks", "grocy", "bookstack",
+    "services", "container", "docker", "balena", "pihole", "turtleblocks", "musicblocks", "grocy",
     "kolibri", "mongodb", "moodle", "netdata", "nextcloud", "ntopng", "planet", "invoiceninja", "librespeed",
-    "portainer", "privatebin", "mastodon", "couchdb", "mariadb", "seafile", "minetest"
+    "portainer", "privatebin", "mastodon", "couchdb", "mariadb", "seafile", "minetest", "bookstack"
   ],
   "author": {
     "name": "OLE treehouses team",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.21.19",
+  "version": "1.21.36",
   "remote": "2346",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",

--- a/services/install-bookstack.sh
+++ b/services/install-bookstack.sh
@@ -78,7 +78,7 @@ function get_ports {
 
 # add size (in MB)
 function get_size {
-  echo "<size>"
+  echo "308"
 }
 
 # add info

--- a/services/install-bookstack.sh
+++ b/services/install-bookstack.sh
@@ -20,7 +20,7 @@ services:
     volumes:
       - /srv/bookstack:/root/.bookstack
     ports:
-      - 6875:80
+      - 8092:80
     restart: unless-stopped
     depends_on:
       - bookstack_db
@@ -72,7 +72,7 @@ function supported_arms {
 
 # add port(s)
 function get_ports {
-  echo "6875"
+  echo "8092"
 }
 
 # add size (in MB)

--- a/services/install-bookstack.sh
+++ b/services/install-bookstack.sh
@@ -86,6 +86,7 @@ function get_info {
   echo
   echo "Bookstack is a free and open source Wiki designed for creating beautiful documentation"
   echo "It featrues a simple, but powerful WYSIWYG editor that allows teams to create detailed and useful documentation with ease."
+  echo "The default username is admin@admin.com with the password of password."
 }
 
 # add svg icon

--- a/services/install-bookstack.sh
+++ b/services/install-bookstack.sh
@@ -10,7 +10,6 @@ version: "2"
 services:
   bookstack:
     image: linuxserver/bookstack
-    container_name: bookstack
     environment:
       - PUID=\${PUID}
       - PGID=\${PGID}
@@ -27,7 +26,6 @@ services:
       - bookstack_db
   bookstack_db:
     image: linuxserver/mariadb
-    container_name: bookstack_db
     environment:
       - PUID=\${PUID}
       - PGID=\${PGID}
@@ -56,7 +54,8 @@ bookstack_autorun=true
 
 if [ "$bookstack_autorun" = true ]; then
   treehouses services bookstack up
-fi
+fi 
+
 
 EOF
 }

--- a/services/install-bookstack.sh
+++ b/services/install-bookstack.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+function install {
+  # create service directory
+  mkdir -p /srv/bookstack
+
+  # create yml(s)
+  cat << EOF > /srv/bookstack/bookstack.yml
+version: "2"
+services:
+  bookstack:
+    image: linuxserver/bookstack
+    container_name: bookstack
+    environment:
+      - PUID=\${PUID}
+      - PGID=\${PGID}
+      - DB_HOST=bookstack_db
+      - DB_USER=\${DB_USERNAME}
+      - DB_PASS=\${DB_PASSWORD}
+      - DB_DATABASE=\${DB_DATABASE}
+    volumes:
+      - /srv/bookstack:/root/.bookstack
+    ports:
+      - 6875:80
+    restart: unless-stopped
+    depends_on:
+      - bookstack_db
+  bookstack_db:
+    image: linuxserver/mariadb
+    container_name: bookstack_db
+    environment:
+      - PUID=\${PUID}
+      - PGID=\${PGID}
+      - MYSQL_ROOT_PASSWORD=\${DB_PASSWORD}
+      - TZ=Europe/London
+      - MYSQL_DATABASE=\${DB_DATABASE}
+      - MYSQL_USER=\${DB_USERNAME}
+      - MYSQL_PASSWORD=\${DB_PASSWORD}
+    volumes:
+      - /srv/bookstack:/root/.bookstack
+    restart: unless-stopped
+EOF
+
+  # create .env with default values
+  cat << EOF > /srv/bookstack/.env
+PUID=1000
+PGID=1000
+DB_USERNAME=db_username
+DB_PASSWORD=db_password 
+DB_DATABASE=bookstackapp
+EOF
+
+  # add autorun
+  cat << EOF > /srv/bookstack/autorun
+bookstack_autorun=true
+
+if [ "$bookstack_autorun" = true ]; then
+  treehouses services bookstack up
+fi
+
+EOF
+}
+
+# environment var
+function uses_env {
+  echo true
+}
+
+# add supported arm(s)
+function supported_arms {
+  echo "v7l"
+}
+
+# add port(s)
+function get_ports {
+  echo "6875"
+}
+
+# add size (in MB)
+function get_size {
+  echo "<size>"
+}
+
+# add info
+function get_info {
+  echo "https://github.com/linuxserver/docker-bookstack"
+  echo
+  echo "Bookstack is a free and open source Wiki designed for creating beautiful documentation"
+  echo "It featrues a simple, but powerful WYSIWYG editor that allows teams to create detailed and useful documentation with ease."
+}
+
+# add svg icon
+function get_icon {
+  cat <<EOF
+<svg id="svg4200" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="61.699mm" width="65.023mm" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" viewBox="0 0 230.39711 218.6199">
+ <g id="layer1" stroke-linejoin="round" fill-rule="evenodd" transform="translate(-245.27 -58.434)" stroke="#0288d1" stroke-width="6" fill="#fff">
+  <g stroke-linecap="round">
+   <path id="path5686" d="m343.79 238.6 128.88-74.409-92.058-53.15-128.88 74.409z"></path>
+   <path id="path5688" d="m251.73 185.45v21.26l92.058 53.15 128.88-74.409v-21.26"></path>
+   <path id="path5694" d="m343.79 274.03-92.058-53.15s-7.5-16.918 0-28.346l92.058 53.15 128.88-74.409v28.346l-128.88 74.409"></path>
+   <path id="path5686-5" d="m343.79 188.99 128.88-74.41-92.06-53.146-128.88 74.406z"></path>
+   <path id="path5692-7" d="m343.79 188.99 128.88-74.409 0.00001 28.346-128.88 74.409-92.058-53.15s-6.0714-17.632 0-28.346z"></path>
+   <path id="path5694-5" d="m343.79 245.69-92.058-53.15s-7.5-16.918 0-28.346l92.058 53.15 128.88-74.409-0.00001 28.346-128.88 74.409"></path>
+  </g>
+  <path id="path5831" d="m402.09 73.836-55.234 31.89 21.48 1.7716 3.0686 12.402 55.235-31.89z"></path>
+ </g>
+</svg>
+EOF
+}

--- a/tests/services/bookstack.bats
+++ b/tests/services/bookstack.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+load ../test-helper
+
+@test "$clinom services bookstack info" {
+  run "${clicmd}" services bookstack info
+  assert_success && assert_output -p 'https://github.com/linuxserver/docker-bookstack'
+}
+
+@test "$clinom services bookstack install" {
+  run "${clicmd}" services bookstack install
+  assert_success && assert_output -p 'installed'
+}
+
+@test "$clinom services bookstack up" {
+  run "${clicmd}" services bookstack up
+  sleep 5
+  assert_success && assert_output -p 'bookstack built and started'
+}
+
+@test "$clinom services bookstack start" {
+  run "${clicmd}" services bookstack start
+  sleep 5
+  assert_success && assert_output -p 'bookstack started'
+}
+
+@test "$clinom services bookstack restart" {
+  run "${clicmd}" services bookstack restart
+  sleep 5
+  assert_success && assert_output -p 'bookstack built and started'
+}
+
+@test "$clinom services available" {
+  run "${clicmd}" services available
+  assert_success && assert_output -p 'bookstack'
+}
+
+@test "$clinom services running" {
+  run "${clicmd}" services running
+  assert_success && assert_output -p 'bookstack'
+}
+
+@test "$clinom services running full" {
+  run "${clicmd}" services running full
+  assert_success && assert_output -p 'linuxserver/bookstack'
+}
+
+@test "$clinom services installed" {
+  run "${clicmd}" services installed
+  assert_success && assert_output -p 'bookstack'
+}
+
+@test "$clinom services installed full" {
+  run "${clicmd}" services installed full
+  assert_success && assert_output -p 'linuxserver/bookstack'
+}
+
+@test "$clinom services ports" {
+  run "${clicmd}" services ports
+  assert_success && assert_output -p 'port 80'
+}
+
+@test "$clinom services bookstack port" {
+  run "${clicmd}" services bookstack port
+  assert_success && assert_output -p '6875'
+}
+
+@test "$clinom services bookstack ps" {
+  run "${clicmd}" services bookstack ps
+  assert_success && assert_output -p 'linuxserver/bookstack'
+}
+
+@test "$clinom services bookstack url" {
+  run "${clicmd}" services bookstack url
+  assert_output -p '6875'
+}
+
+@test "$clinom services bookstack autorun" {
+  run "${clicmd}" services bookstack autorun
+  assert_success
+}
+
+@test "$clinom services bookstack autorun true" {
+  run "${clicmd}" services bookstack autorun true
+  assert_success && assert_output -p 'set to true'
+}
+
+@test "$clinom services bookstack stop" {
+  run "${clicmd}" services bookstack stop
+  assert_success && assert_output -p 'bookstack stopped'
+}
+
+@test "$clinom services bookstack down" {
+  run "${clicmd}" services bookstack down
+  assert_success && assert_output -p 'bookstack stopped and removed'
+}
+
+@test "$clinom services bookstack icon" {
+  run "${clicmd}" services bookstack icon
+  assert_success && assert_output -p 'svg'
+}
+
+@test "$clinom services bookstack cleanup" {
+  run "${clicmd}" services bookstack cleanup
+  assert_success && assert_output -p 'cleaned up'
+}

--- a/tests/services/bookstack.bats
+++ b/tests/services/bookstack.bats
@@ -61,7 +61,7 @@ load ../test-helper
 
 @test "$clinom services bookstack port" {
   run "${clicmd}" services bookstack port
-  assert_success && assert_output -p '6875'
+  assert_success && assert_output -p '8092'
 }
 
 @test "$clinom services bookstack ps" {
@@ -71,7 +71,7 @@ load ../test-helper
 
 @test "$clinom services bookstack url" {
   run "${clicmd}" services bookstack url
-  assert_output -p '6875'
+  assert_output -p '8092'
 }
 
 @test "$clinom services bookstack autorun" {


### PR DESCRIPTION
fixes #1340 
```
root@treehouses:/home/pi/cli# ./cli.sh services bookstack install
Pulling bookstack_db ... done
Pulling bookstack    ... done
bookstack installed
modify default environment variables by running 'cli.sh services bookstack config edit'
root@treehouses:/home/pi/cli# ./cli.sh services bookstack up
valid yml
Creating network "bookstack_default" with the default driver
Creating bookstack_db ... done
Creating bookstack    ... done
bookstack built and started
root@treehouses:/home/pi/cli# ./cli.sh services bookstack start
Starting bookstack_db ... done
Starting bookstack    ... done
bookstack started
root@treehouses:/home/pi/cli# ./cli.sh services bookstack ps
1a66794a1d34        linuxserver/bookstack             "/init"                  31 seconds ago      Up 27 seconds            443/tcp, 0.0.0.0:6875->80/tcp                bookstack
f39af61e18c4        linuxserver/mariadb               "/init"                  33 seconds ago      Up 31 seconds            3306/tcp
```
successfully running on my device
![HIMP - 2020-06-03 19:25:49](https://user-images.githubusercontent.com/51189233/83631453-2160e400-a5d0-11ea-8767-678b166f3484.png)
