### PR TITLE
`treehouses gpio` only rpi (fixes #1387)

### DIFF
--- a/modules/gpio.sh
+++ b/modules/gpio.sh
@@ -1,5 +1,6 @@
 function gpio {
   checkargn $# 0
+  checkrpi
   model="$(detectrpi)"
   prefix="${model:0:2}"
   oldrpi="True"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.21.25",
+  "version": "1.21.37",
   "remote": "2346",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
fixes #1387

- added `checkrpi`