### PR TITLE
`treehouses editor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ changelog [view|compare]                  displays the most recent changes to tr
 magazine <hackspace|magpi|wireframe>      downloads specific magazine issue as a pdf based on user input
          <helloworld> [all|latest|number]
 resolution <cea|dmt [modes]>              sets the screen resolution
+editor [default|set|config]               sets file default editor and editor configuration file
 shutdown [now|in|force]                   shutdown the system
 ```
 

--- a/_treehouses
+++ b/_treehouses
@@ -362,6 +362,11 @@ treehouses wifihidden
 treehouses wifistatus
 treehouses convert
 treehouses resolution
+treehouses editor default
+treehouses editor set vim
+treehouses editor set emacs
+treehouses editor set nano
+treehouses editor config
 EOF
 # COMP_LINE is the line you typed in terminal
 # COMP_WORDS is array form of COMP_LINE

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -39,6 +39,8 @@ function editor {
       cp "$TEMPLATES/editor/vim/vimrc_default" /etc/vim/vimrc 
       cp "$TEMPLATES/editor/nano/nanorc_default" /etc/nanorc
       rm -rf /etc/vim/vimrc.local
+      echo "Text editor is now vim, using the default config."
+      exit 0
       ;;
 
     set)
@@ -59,8 +61,10 @@ function editor {
           else
             sed -i -e "s/EDITOR=.*/EDITOR=$i/g" /etc/bash.bashrc
           fi 
+          "Text editor is now $i."
           exit 0
         fi 
+
         if [ "$i" == "$(echo $supported_editor | egrep -o '\S+$')" ]; then
           echo
           echo "Error: $2 is not a supported text editor."
@@ -92,6 +96,8 @@ function editor {
           emacs)
             ;;
         esac
+        echo "$EDITOR is now using config from file \"$2\"."
+        exit 0
 
       elif [ "$2" == "alternate" ]; then
         case "$EDITOR" in 
@@ -106,6 +112,25 @@ function editor {
           emacs)
             ;;
         esac
+        echo "$EDITOR is now using the alternate config."
+        exit 0
+
+      elif [ "$2" == "edit" ]; then
+        case "$EDITOR" in
+          vim)
+            if [ ! -f /etc/vimrc/vimrc.local ]; then
+              cp "$TEMPLATES/editor/vim/vimrc_default" /etc/vim/vimrc.local
+            fi
+            vim /etc/vim/vimrc.local
+            ;;
+          nano)
+            nano /etc/nanorc
+            ;;
+          emacs)
+            ;;
+        esac
+        echo "$EDITOR is now using the alternate config."
+        exit 0
 
       elif [ "$2" == "default" ]; then
         case "$EDITOR" in 
@@ -119,12 +144,15 @@ function editor {
           emacs)
             ;;
         esac
+        echo "$EDITOR config reset to default."
+        exit 0
 
       else
         echo
-        echo "Error: No such option as $2."
-        echo "Use \"$BASENAME editor config [/path/to/file]\""
-        echo "or \"$BASENAME editor config [default/alternate]\""
+        echo "Error: No such option as \"$2\"."
+        echo "Usages: \"$BASENAME editor config [/path/to/file]\""
+        echo "        \"$BASENAME editor config [default/alternate]\""
+        echo "        \"$BASENAME editor config edit\""
         echo
         exit 1
       fi
@@ -132,7 +160,7 @@ function editor {
 
     *)
       echo 
-      echo "Error: Arguments error."
+      echo "Error: No such option as \"$1\"."
       echo
       editor_help
       exit 1
@@ -153,5 +181,6 @@ function editor_help {
   echo "       $BASENAME editor config [/path/to/file]  sets a file as the config of current editor"
   echo "       $BASENAME editor config default          uses default config for current editor"
   echo "       $BASENAME editor config alternate        uses alternate config for current editor"
+  echo "       $BASENAME editor config edit             edit config of the current editor"
   echo 
 }

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -3,20 +3,28 @@
 function editor {
   checkroot
 
-  if [ -z "$EDITOR" ]; then
-    if grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
-      EDITOR="$(grep EDITOR /etc/bash.bashrc | grep export | sed 's/export EDITOR=//g')"
-    else
+  if grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
+    EDITOR="$(grep EDITOR /etc/bash.bashrc | grep export | sed 's/export EDITOR=//g')"
+  else
+
+  if [ -z "$EDITOR" ] && [ "$1" =="config" ]; then
+    echo
+    echo "Default editor not set."
+    echo "Use \"treehouses editor default\""
+    echo "or \"treehouses editor set [vim|emacs|nano]\" to set your default editor."
+    echo
+    exit 1
+  fi 
+
+  if [ $# -eq 0 ]; then
+    if [ -z "$EDITOR" ]; then
       echo
       echo "Default editor not set."
       echo "Use \"treehouses editor default\""
       echo "or \"treehouses editor set [vim|emacs|nano]\" to set your default editor."
       echo
       exit 1
-    fi
-  fi 
-
-  if [ $# -eq 0 ]; then
+    fi 
     echo $EDITOR
     exit 0
   fi

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -118,9 +118,6 @@ function editor {
       elif [ "$2" == "edit" ]; then
         case "$EDITOR" in
           vim)
-            if [ ! -f /etc/vimrc/vimrc.local ]; then
-              cp "$TEMPLATES/editor/vim/vimrc_default" /etc/vim/vimrc.local
-            fi
             vim /etc/vim/vimrc.local
             ;;
           nano)

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -7,7 +7,7 @@ function editor {
     EDITOR="$(grep EDITOR /etc/bash.bashrc | grep export | sed 's/export EDITOR=//g')"
   fi
 
-  if [ -z "$EDITOR" ] && [ "$1" =="config" ]; then
+  if [ -z "$EDITOR" ] && [ "$1" == "config" ]; then
     echo
     echo "Default editor not set."
     echo "Use \"treehouses editor default\""

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -3,7 +3,7 @@
 function editor {
   checkroot
 
-  if [ -z "$EDITOR" ] && [ "$1" == "config" ]; then
+  if [ -z "$EDITOR" ]; then
     if grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
       EDITOR="$(grep EDITOR /etc/bash.bashrc | grep export | sed 's/export EDITOR=//g')"
     else

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -1,0 +1,129 @@
+#! /bin/bash 
+
+function editor {
+  checkroot
+
+  if [ -z "$EDITOR" ]; then
+    echo
+    echo "Default editor not set."
+    echo "Use \"treehouses editor default\""
+    echo "or \"treehouses editor set [vim|emacs|nano]\" to set your default editor."
+    echo
+    exit 1
+  fi 
+
+  if [ $# -eq 0 ]; then
+    echo $EDITOR
+  fi
+
+  case "$1" in 
+    default)
+      export EDITOR=vim
+      if ! grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
+        echo "export EDITOR=vim" >> /etc/bash.bashrc
+      else
+        sed -i -e "s/EDITOR=.*/EDITOR=vim/g" /etc/bash.bashrc
+      fi
+      cp "$TEMPLATES/editor/vim/vimrc_default" /etc/vim/vimrc 
+      cp "$TEMPLATES/editor/nano/nanorc_default" /etc/nanorc
+      rm -rf /etc/vim/vimrc.local
+      ;;
+
+    set)
+      if [ $# -lt 2 ]; then 
+        echo
+        echo "No editor specified."
+        echo
+        exit 1
+      fi
+
+      case "$2" in 
+        vim)
+          export EDITOR=vim 
+          if ! grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
+            echo "export EDITOR=vim" >> /etc/bash.bashrc
+          else
+            sed -i -e "s/EDITOR=.*/EDITOR=vim/g" /etc/bash.bashrc
+          fi
+          ;;
+        nano)
+          export EDITOR=nano
+          if ! grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
+            echo "export EDITOR=nano" >> /etc/bash.bashrc
+          else
+            sed -i -e "s/EDITOR=.*/EDITOR=nano/g" /etc/bash.bashrc
+          fi
+          ;;
+        emacs)
+          ;;
+        *)
+          echo
+          echo "$2 is not a supported text editor."
+          echo
+          exit 1
+          ;;
+      esac
+      ;;
+
+    config)
+      if [ $# -lt 2 ]; then 
+        echo
+        echo "No config file specified."
+        echo
+        exit 1
+      fi 
+
+      if [ -f "$2" ]; then
+        case "$EDITOR" in 
+            vim)
+            cp "$2" /etc/vim/vimrc.local 
+            ;;
+          nano)
+            cp "$2" /etc/nanorc
+            ;;
+          emacs)
+            ;;
+        esac
+
+      elif [ "$2" == "alternate" ]; then
+        case "$EDITOR" in 
+          vim)
+            cp "$TEMPLATES/editor/vim/vimrc_alternate" /etc/vim/vimrc.local
+            cp "$TEMPLATES/editor/vim/vimrc_default" /etc/vim/vimrc
+            ;;
+          nano)
+            ;;
+          emacs)
+            ;;
+        esac
+      else
+        echo
+        echo "Arguments error."
+        echo
+        exit 1
+      fi
+      ;;
+
+    *)
+      echo 
+      echo "Arguments error."
+      echo
+      exit 1
+      ;;
+  esac
+
+}
+
+function editor_help {
+  echo 
+  echo "Usage: $BASENAME editor [default|set|config]"
+  echo 
+  echo "       $BASENAME editor                         returns the default editor"
+  echo
+  echo "       $BASENAME editor default                 sets vim as default editor and resets config"
+  echo 
+  echo "       $BASENAME editor set [vim|emacs|nano]    sets the default editor"
+  echo 
+  echo "       $BASENAME editor config [/path/to/file]  use a file as the config of the editor"
+  echo 
+}

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -3,7 +3,7 @@
 function editor {
   checkroot
 
-  if [ -z "$EDITOR" ] && [ "$1" != "set" ]; then
+  if [ -z "$EDITOR" ] && [ "$1" == "config" ]; then
     echo
     echo "Default editor not set."
     echo "Use \"treehouses editor default\""

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -46,6 +46,7 @@ function editor {
         echo
         echo "Error: No editor specified."
         echo
+        editor_help
         exit 1
       fi
 
@@ -64,6 +65,7 @@ function editor {
           echo
           echo "Error: $2 is not a supported text editor."
           echo
+          editor_help
           exit 1
         fi
       done
@@ -74,6 +76,7 @@ function editor {
         echo
         echo "Error: No config file specified."
         echo
+        editor_help
         exit 1
       fi 
 
@@ -131,6 +134,7 @@ function editor {
       echo 
       echo "Error: Arguments error."
       echo
+      editor_help
       exit 1
       ;;
   esac
@@ -146,8 +150,8 @@ function editor_help {
   echo 
   echo "       $BASENAME editor set [vim|emacs|nano]    sets the default editor"
   echo 
-  echo "       $BASENAME editor config [/path/to/file]  use a file as the config of the editor"
-  echo "       $BASENAME editor config default          use default config for current editor"
-  echo "       $BASENAME editor config alternate        use alternate config for current editor"
+  echo "       $BASENAME editor config [/path/to/file]  sets a file as the config of current editor"
+  echo "       $BASENAME editor config default          uses default config for current editor"
+  echo "       $BASENAME editor config alternate        uses alternate config for current editor"
   echo 
 }

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -5,7 +5,7 @@ function editor {
 
   if grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
     EDITOR="$(grep EDITOR /etc/bash.bashrc | grep export | sed 's/export EDITOR=//g')"
-  else
+  fi
 
   if [ -z "$EDITOR" ] && [ "$1" =="config" ]; then
     echo

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -61,7 +61,7 @@ function editor {
           else
             sed -i -e "s/EDITOR=.*/EDITOR=$i/g" /etc/bash.bashrc
           fi 
-          "Text editor is now $i."
+          echo "Text editor is now $i."
           exit 0
         fi 
 

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -14,6 +14,7 @@ function editor {
 
   if [ $# -eq 0 ]; then
     echo $EDITOR
+    exit 0
   fi
 
   case "$1" in 

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -3,7 +3,7 @@
 function editor {
   checkroot
 
-  if [ -z "$EDITOR" ]; then
+  if [ -z "$EDITOR" ] && [ "$1" == "set" ]; then
     echo
     echo "Default editor not set."
     echo "Use \"treehouses editor default\""

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -3,7 +3,7 @@
 function editor {
   checkroot
 
-  if [ -z "$EDITOR" ] && [ "$1" == "set" ]; then
+  if [ -z "$EDITOR" ] && [ "$1" != "set" ]; then
     echo
     echo "Default editor not set."
     echo "Use \"treehouses editor default\""

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -126,7 +126,6 @@ function editor {
           emacs)
             ;;
         esac
-        echo "$EDITOR is now using the alternate config."
         exit 0
 
       elif [ "$2" == "default" ]; then

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -9,7 +9,7 @@ function editor {
 
   if [ -z "$EDITOR" ] && [ "$1" == "config" ]; then
     echo
-    echo "Default editor not set."
+    echo "Error: default editor not set."
     echo "Use \"treehouses editor default\""
     echo "or \"treehouses editor set [vim|emacs|nano]\" to set your default editor."
     echo
@@ -19,7 +19,7 @@ function editor {
   if [ $# -eq 0 ]; then
     if [ -z "$EDITOR" ]; then
       echo
-      echo "Default editor not set."
+      echo "Error: default editor not set."
       echo "Use \"treehouses editor default\""
       echo "or \"treehouses editor set [vim|emacs|nano]\" to set your default editor."
       echo
@@ -44,7 +44,7 @@ function editor {
     set)
       if [ $# -lt 2 ]; then 
         echo
-        echo "No editor specified."
+        echo "Error: No editor specified."
         echo
         exit 1
       fi
@@ -65,10 +65,15 @@ function editor {
           fi
           ;;
         emacs)
+          if ! grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
+            echo "export EDITOR=emacs" >> /etc/bash.bashrc
+          else
+            sed -i -e "s/EDITOR=.*/EDITOR=emacs/g" /etc/bash.bashrc
+          fi
           ;;
         *)
           echo
-          echo "$2 is not a supported text editor."
+          echo "Error: $2 is not a supported text editor."
           echo
           exit 1
           ;;
@@ -78,7 +83,7 @@ function editor {
     config)
       if [ $# -lt 2 ]; then 
         echo
-        echo "No config file specified."
+        echo "Error: No config file specified."
         echo
         exit 1
       fi 
@@ -89,7 +94,8 @@ function editor {
             cp "$2" /etc/vim/vimrc.local 
             ;;
           nano)
-            cp "$2" /etc/nanorc
+            cp "$TEMPLATES/editor/nano/nanorc_default" /etc/nanorc 
+            cat "$2" >> /etc/nanorc
             ;;
           emacs)
             ;;
@@ -102,13 +108,17 @@ function editor {
             cp "$TEMPLATES/editor/vim/vimrc_default" /etc/vim/vimrc
             ;;
           nano)
+            cp "$TEMPLATES/editor/nano/nanorc_default" /etc/nanorc 
+            cat "$TEMPLATES/editor/nano/nanorc_alternate" >> /etc/nanorc
             ;;
           emacs)
             ;;
         esac
       else
         echo
-        echo "Arguments error."
+        echo "Error: No such option as $2."
+        echo "Use \"$BASENAME editor config [/path/to/file]\""
+        echo "or \"$BASENAME editor config alternate\""
         echo
         exit 1
       fi
@@ -116,7 +126,7 @@ function editor {
 
     *)
       echo 
-      echo "Arguments error."
+      echo "Error: Arguments error."
       echo
       exit 1
       ;;

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -49,35 +49,24 @@ function editor {
         exit 1
       fi
 
-      case "$2" in 
-        vim)
+      supported_editor="vim nano emacs"
+      
+      for i in $supported_editor; do 
+        if [ "$i" == "$2" ]; then
           if ! grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
-            echo "export EDITOR=vim" >> /etc/bash.bashrc
+            echo "export EDITOR=$i" >> /etc/bash.bashrc
           else
-            sed -i -e "s/EDITOR=.*/EDITOR=vim/g" /etc/bash.bashrc
-          fi
-          ;;
-        nano)
-          if ! grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
-            echo "export EDITOR=nano" >> /etc/bash.bashrc
-          else
-            sed -i -e "s/EDITOR=.*/EDITOR=nano/g" /etc/bash.bashrc
-          fi
-          ;;
-        emacs)
-          if ! grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
-            echo "export EDITOR=emacs" >> /etc/bash.bashrc
-          else
-            sed -i -e "s/EDITOR=.*/EDITOR=emacs/g" /etc/bash.bashrc
-          fi
-          ;;
-        *)
+            sed -i -e "s/EDITOR=.*/EDITOR=$i/g" /etc/bash.bashrc
+          fi 
+          exit 0
+        fi 
+        if [ "$i" == "$(echo $supported_editor | egrep -o '\S+$')" ]; then
           echo
           echo "Error: $2 is not a supported text editor."
           echo
           exit 1
-          ;;
-      esac
+        fi
+      done
       ;;
 
     config)
@@ -114,11 +103,25 @@ function editor {
           emacs)
             ;;
         esac
+
+      elif [ "$2" == "default" ]; then
+        case "$EDITOR" in 
+          vim)
+            cp "$TEMPLATES/editor/vim/vimrc_default" /etc/vim/vimrc 
+            rm -rf /etc/vim/vimrc.local
+            ;;
+          nano)
+            cp "$TEMPLATES/editor/nano/nanorc_default" /etc/nanorc 
+            ;;
+          emacs)
+            ;;
+        esac
+
       else
         echo
         echo "Error: No such option as $2."
         echo "Use \"$BASENAME editor config [/path/to/file]\""
-        echo "or \"$BASENAME editor config alternate\""
+        echo "or \"$BASENAME editor config [default/alternate]\""
         echo
         exit 1
       fi
@@ -131,7 +134,6 @@ function editor {
       exit 1
       ;;
   esac
-
 }
 
 function editor_help {
@@ -145,5 +147,7 @@ function editor_help {
   echo "       $BASENAME editor set [vim|emacs|nano]    sets the default editor"
   echo 
   echo "       $BASENAME editor config [/path/to/file]  use a file as the config of the editor"
+  echo "       $BASENAME editor config default          use default config for current editor"
+  echo "       $BASENAME editor config alternate        use alternate config for current editor"
   echo 
 }

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -4,12 +4,16 @@ function editor {
   checkroot
 
   if [ -z "$EDITOR" ] && [ "$1" == "config" ]; then
-    echo
-    echo "Default editor not set."
-    echo "Use \"treehouses editor default\""
-    echo "or \"treehouses editor set [vim|emacs|nano]\" to set your default editor."
-    echo
-    exit 1
+    if grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
+      EDITOR="$(grep EDITOR /etc/bash.bashrc | grep export | sed 's/export EDITOR=//g')"
+    else
+      echo
+      echo "Default editor not set."
+      echo "Use \"treehouses editor default\""
+      echo "or \"treehouses editor set [vim|emacs|nano]\" to set your default editor."
+      echo
+      exit 1
+    fi
   fi 
 
   if [ $# -eq 0 ]; then
@@ -24,7 +28,6 @@ function editor {
       else
         sed -i -e "s/EDITOR=.*/EDITOR=vim/g" /etc/bash.bashrc
       fi
-      source /etc/bash.bashrc
       cp "$TEMPLATES/editor/vim/vimrc_default" /etc/vim/vimrc 
       cp "$TEMPLATES/editor/nano/nanorc_default" /etc/nanorc
       rm -rf /etc/vim/vimrc.local
@@ -45,7 +48,6 @@ function editor {
           else
             sed -i -e "s/EDITOR=.*/EDITOR=vim/g" /etc/bash.bashrc
           fi
-          source /etc/bash.bashrc
           ;;
         nano)
           if ! grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
@@ -53,7 +55,6 @@ function editor {
           else
             sed -i -e "s/EDITOR=.*/EDITOR=nano/g" /etc/bash.bashrc
           fi
-          source /etc/bash.bashrc
           ;;
         emacs)
           ;;

--- a/modules/editor.sh
+++ b/modules/editor.sh
@@ -19,12 +19,12 @@ function editor {
 
   case "$1" in 
     default)
-      export EDITOR=vim
       if ! grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
         echo "export EDITOR=vim" >> /etc/bash.bashrc
       else
         sed -i -e "s/EDITOR=.*/EDITOR=vim/g" /etc/bash.bashrc
       fi
+      source /etc/bash.bashrc
       cp "$TEMPLATES/editor/vim/vimrc_default" /etc/vim/vimrc 
       cp "$TEMPLATES/editor/nano/nanorc_default" /etc/nanorc
       rm -rf /etc/vim/vimrc.local
@@ -40,20 +40,20 @@ function editor {
 
       case "$2" in 
         vim)
-          export EDITOR=vim 
           if ! grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
             echo "export EDITOR=vim" >> /etc/bash.bashrc
           else
             sed -i -e "s/EDITOR=.*/EDITOR=vim/g" /etc/bash.bashrc
           fi
+          source /etc/bash.bashrc
           ;;
         nano)
-          export EDITOR=nano
           if ! grep EDITOR /etc/bash.bashrc | grep -q export /etc/bash.bashrc; then
             echo "export EDITOR=nano" >> /etc/bash.bashrc
           else
             sed -i -e "s/EDITOR=.*/EDITOR=nano/g" /etc/bash.bashrc
           fi
+          source /etc/bash.bashrc
           ;;
         emacs)
           ;;

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -113,6 +113,7 @@ changelog                                 displays the most recent changes to tr
 magazine <hackspace|magpi|wireframe>      downloads specific magazine issue as a pdf based on user input
          <helloworld> [all|latest|number]
 resolution <cea|dmt [modes]>              sets the screen resolution
+editor [default|set|config]               sets default file editor and editor configuration file
 shutdown [now|in|force]                   shutdown the system
 EOF
   echo "$helpdefault"

--- a/templates/editor/nano/nanorc_alternate
+++ b/templates/editor/nano/nanorc_alternate
@@ -1,0 +1,6 @@
+set linenumbers
+set tabsize 2
+set autoindent
+
+include "/usr/share/nano/*.nanorc"
+

--- a/templates/editor/nano/nanorc_alternate
+++ b/templates/editor/nano/nanorc_alternate
@@ -1,3 +1,4 @@
+
 set linenumbers
 set tabsize 2
 set autoindent

--- a/templates/editor/nano/nanorc_alternate
+++ b/templates/editor/nano/nanorc_alternate
@@ -1,6 +1,7 @@
 set linenumbers
 set tabsize 2
 set autoindent
+set smooth
 
 include "/usr/share/nano/*.nanorc"
 

--- a/templates/editor/nano/nanorc_default
+++ b/templates/editor/nano/nanorc_default
@@ -1,0 +1,272 @@
+## Sample initialization file for GNU nano.
+##
+## Please note that you must have configured nano with --enable-nanorc
+## for this file to be read!  Also note that this file should not be in
+## DOS or Mac format, and that characters specially interpreted by the
+## shell should not be escaped here.
+##
+## To make sure an option is disabled, use "unset <option>".
+##
+## For the options that take parameters, the default value is given.
+## Other options are unset by default.
+##
+## Quotes inside string parameters don't have to be escaped with
+## backslashes.  The last double quote in the string will be treated as
+## its end.  For example, for the "brackets" option, ""')>]}" will match
+## ", ', ), >, ], and }.
+
+## Make the 'nextword' function (Ctrl+Right) stop at word ends
+## instead of at beginnings.
+# set afterends
+
+## When soft line wrapping is enabled, make it wrap lines at blanks
+## (tabs and spaces) instead of always at the edge of the screen.
+# set atblanks
+
+## Automatically indent a newly created line to the same number of
+## tabs and/or spaces as the preceding line -- or as the next line
+## if the preceding line is the beginning of a paragraph.
+# set autoindent
+
+## Back up files to the current filename plus a tilde.
+# set backup
+
+## The directory to put unique backup files in.
+# set backupdir ""
+
+## Use bold text instead of reverse video text.
+# set boldtext
+
+## The characters treated as closing brackets when justifying paragraphs.
+## This may not include any blank characters.  Only closing punctuation,
+## optionally followed by these closing brackets, can end sentences.
+# set brackets ""')>]}"
+
+## Do case-sensitive searches by default.
+# set casesensitive
+
+## Constantly display the cursor position in the status bar.  Note that
+## this overrides "quickblank".
+# set constantshow
+
+## Use cut-from-cursor-to-end-of-line by default.
+# set cutfromcursor
+## (The old form, 'cut', is deprecated.)
+
+## Set the line length for wrapping text and justifying paragraphs.
+## If the value is 0 or less, the wrapping point will be the screen
+## width less this number.
+# set fill -8
+
+## Remember the used search/replace strings for the next session.
+set historylog
+
+## Display line numbers to the left of the text.
+# set linenumbers
+
+## Enable vim-style lock-files.  This is just to let a vim user know you
+## are editing a file [s]he is trying to edit and vice versa.  There are
+## no plans to implement vim-style undo state in these files.
+set locking
+
+## The opening and closing brackets that can be found by bracket
+## searches.  They cannot contain blank characters.  The former set must
+## come before the latter set, and both must be in the same order.
+# set matchbrackets "(<[{)>]}"
+
+## Use the blank line below the title bar as extra editing space.
+# set morespace
+
+## Enable mouse support, if available for your system.  When enabled,
+## mouse clicks can be used to place the cursor, set the mark (with a
+## double click), and execute shortcuts.  The mouse will work in the X
+## Window System, and on the console when gpm is running.
+# set mouse
+
+## Switch on multiple file buffers (inserting a file will put it into
+## a separate buffer).
+# set multibuffer
+
+## Don't convert files from DOS/Mac format.
+# set noconvert
+
+## Don't display the helpful shortcut lists at the bottom of the screen.
+# set nohelp
+
+## Don't automatically add a newline when a file does not end with one.
+# set nonewlines
+
+## Don't pause between warnings at startup.  Which means that only the
+## last one will be readable (when there are multiple ones).
+# set nopauses
+
+## Don't wrap text at all.
+set nowrap
+
+## Set operating directory.  nano will not read or write files outside
+## this directory and its subdirectories.  Also, the current directory
+## is changed to here, so any files are inserted from this dir.  A blank
+## string means the operating-directory feature is turned off.
+# set operatingdir ""
+
+## Remember the cursor position in each file for the next editing session.
+# set positionlog
+
+## Preserve the XON and XOFF keys (^Q and ^S).
+# set preserve
+
+## The characters treated as closing punctuation when justifying
+## paragraphs.  They cannot contain blank characters.  Only closing
+## punctuation, optionally followed by closing brackets, can end
+## sentences.
+# set punct "!.?"
+
+## Do quick status-bar blanking.  Status-bar messages will disappear after
+## 1 keystroke instead of 26.  Note that "constantshow" overrides this.
+# set quickblank
+
+## The email-quote string, used to justify email-quoted paragraphs.
+## This is an extended regular expression.  The default is:
+# set quotestr "^([     ]*([#:>|}]|//))+"
+
+## Fix Backspace/Delete confusion problem.
+# set rebinddelete
+
+## Fix numeric keypad key confusion problem.
+# set rebindkeypad
+
+## Do extended regular expression searches by default.
+# set regexp
+
+## Put the cursor on the highlighted item in the file browser;
+## useful for people who use a braille display.
+# set showcursor
+
+## Make the Home key smarter.  When Home is pressed anywhere but at the
+## very beginning of non-whitespace characters on a line, the cursor
+## will jump to that beginning (either forwards or backwards).  If the
+## cursor is already at that position, it will jump to the true
+## beginning of the line.
+# set smarthome
+
+## Use smooth scrolling as the default.
+# set smooth
+
+## Enable soft line wrapping (AKA full-line display).
+# set softwrap
+
+## Use this spelling checker instead of the internal one.  This option
+## does not have a default value.
+# set speller "aspell -x -c"
+
+## Allow nano to be suspended.
+set suspend
+
+## Use this tab size instead of the default; it must be greater than 0.
+# set tabsize 8
+
+## Convert typed tabs to spaces.
+# set tabstospaces
+
+## Save automatically on exit; don't prompt.
+# set tempfile
+
+## Snip whitespace at the end of lines when justifying or hard-wrapping.
+# set trimblanks
+## (The old form, 'justifytrim', is deprecated.)
+
+## Disallow file modification.  Why would you want this in an rcfile? ;)
+# set view
+
+## The two single-column characters used to display the first characters
+## of tabs and spaces.  187 in ISO 8859-1 (0000BB in Unicode) and 183 in
+## ISO-8859-1 (0000B7 in Unicode) seem to be good values for these.
+## The default when in a UTF-8 locale:
+# set whitespace "»·"
+## The default otherwise:
+# set whitespace ">."
+
+## Detect word boundaries differently by treating punctuation
+## characters as parts of words.
+# set wordbounds
+
+## The characters (besides alphanumeric ones) that should be considered
+## as parts of words.  This option does not have a default value.  When
+## set, it overrides option 'set wordbounds'.
+# set wordchars "<_>."
+
+
+## Paint the interface elements of nano.  These are examples;
+## by default there are no colors, except for errorcolor.
+# set titlecolor brightwhite,blue
+# set statuscolor brightwhite,green
+# set errorcolor brightwhite,red
+# set selectedcolor brightwhite,magenta
+# set numbercolor cyan
+# set keycolor cyan
+# set functioncolor green
+## In root's .nanorc you might want to use:
+# set titlecolor brightwhite,magenta
+# set statuscolor brightwhite,magenta
+# set errorcolor brightwhite,red
+# set selectedcolor brightwhite,cyan
+# set numbercolor magenta
+# set keycolor brightmagenta
+# set functioncolor magenta
+
+
+## Setup of syntax coloring.
+##
+## Format:
+##
+## syntax "short description" ["filename regex" ...]
+##
+## The "none" syntax is reserved; specifying it on the command line is
+## the same as not having a syntax at all.  The "default" syntax is
+## special: it takes no filename regexes, and applies to files that
+## don't match any other syntax's filename regexes.
+##
+## color foreground,background "regex" ["regex"...]
+## or
+## icolor foreground,background "regex" ["regex"...]
+##
+## "color" will do case-sensitive matches, while "icolor" will do
+## case-insensitive matches.
+##
+## Valid colors: white, black, red, blue, green, yellow, magenta, cyan.
+## For foreground colors, you may use the prefix "bright" to get a
+## stronger highlight.
+##
+## To use multi-line regexes, use the start="regex" end="regex"
+## [start="regex" end="regex"...] format.
+##
+## If your system supports transparency, not specifying a background
+## color will use a transparent color.  If you don't want this, be sure
+## to set the background color to black or white.
+##
+## All regexes should be extended regular expressions.
+##
+## If you wish, you may put your syntax definitions in separate files.
+## You can make use of such files as follows:
+##
+## include "/path/to/syntax_file.nanorc"
+##
+## Unless otherwise noted, the name of the syntax file (without the
+## ".nanorc" extension) should be the same as the "short description"
+## name inside that file.  These names are kept fairly short to make
+## them easier to remember and faster to type using nano's -Y option.
+##
+## To include all existing syntax definitions, you can do:
+include "/usr/share/nano/*.nanorc"
+
+
+## Key bindings.
+## See nanorc(5) (section REBINDING KEYS) for more details on this.
+##
+## The following two functions are not bound to any key by default.
+## You may wish to choose other keys than the ones suggested here.
+# bind M-B cutwordleft main
+# bind M-N cutwordright main
+
+## Set this if your Backspace key sends Del most of the time.
+# bind Del backspace all

--- a/templates/editor/vim/vimrc_alternate
+++ b/templates/editor/vim/vimrc_alternate
@@ -1,0 +1,21 @@
+syntax enable
+syntax on 
+
+set number 
+
+nnoremap j gj
+nnoremap k gk
+imap jj <Esc> 
+command Q q
+
+set tabstop=4
+set softtabstop=4
+set shiftwidth=4
+autocmd FileType sh setlocal shiftwidth=2 tabstop=2 softtabstop=2
+
+set ls=2
+
+set incsearch
+set hlsearch
+
+set scrolloff=4

--- a/templates/editor/vim/vimrc_default
+++ b/templates/editor/vim/vimrc_default
@@ -1,0 +1,54 @@
+" All system-wide defaults are set in $VIMRUNTIME/debian.vim and sourced by
+" the call to :runtime you can find below.  If you wish to change any of those
+" settings, you should do it in this file (/etc/vim/vimrc), since debian.vim
+" will be overwritten everytime an upgrade of the vim packages is performed.
+" It is recommended to make changes after sourcing debian.vim since it alters
+" the value of the 'compatible' option.
+
+" This line should not be removed as it ensures that various options are
+" properly set to work with the Vim-related packages available in Debian.
+runtime! debian.vim
+
+" Vim will load $VIMRUNTIME/defaults.vim if the user does not have a vimrc.
+" This happens after /etc/vim/vimrc(.local) are loaded, so it will override
+" any settings in these files.
+" If you don't want that to happen, uncomment the below line to prevent
+" defaults.vim from being loaded.
+" let g:skip_defaults_vim = 1
+
+" Uncomment the next line to make Vim more Vi-compatible
+" NOTE: debian.vim sets 'nocompatible'.  Setting 'compatible' changes numerous
+" options, so any other options should be set AFTER setting 'compatible'.
+"set compatible
+
+" Vim5 and later versions support syntax highlighting. Uncommenting the next
+" line enables syntax highlighting by default.
+"syntax on
+
+" If using a dark background within the editing area and syntax highlighting
+" turn on this option as well
+"set background=dark
+
+" Uncomment the following to have Vim jump to the last position when
+" reopening a file
+"au BufReadPost * if line("'\"") > 1 && line("'\"") <= line("$") | exe "normal! g'\"" | endif
+
+" Uncomment the following to have Vim load indentation rules and plugins
+" according to the detected filetype.
+"filetype plugin indent on
+
+" The following are commented out as they cause vim to behave a lot
+" differently from regular Vi. They are highly recommended though.
+"set showcmd            " Show (partial) command in status line.
+"set showmatch          " Show matching brackets.
+"set ignorecase         " Do case insensitive matching
+"set smartcase          " Do smart case matching
+"set incsearch          " Incremental search
+"set autowrite          " Automatically save before commands like :next and :make
+"set hidden             " Hide buffers when they are abandoned
+"set mouse=a            " Enable mouse usage (all modes)
+
+" Source a global configuration file if available
+if filereadable("/etc/vim/vimrc.local")
+  source /etc/vim/vimrc.local
+endif


### PR DESCRIPTION
commands to set environment variable EDITOR and configure text editors
```
root@treehouses:~/cli# ./cli.sh editor 

Error: default editor not set.
Use "treehouses editor default"
or "treehouses editor set [vim|emacs|nano]" to set your default editor.

root@treehouses:~/cli# ./cli.sh editor set nano
Text editor is now nano.

root@treehouses:~/cli# ./cli.sh editor
nano

root@treehouses:~/cli# ./cli.sh editor default
Text editor is now vim, using the default config.

```
using config from a file
```
root@treehouses:~/cli# echo "set number" > ~/vimrc

root@treehouses:~/cli# ./cli.sh editor config ~/vimrc
vim is now using config from file "/root/vimrc".
```
reset config to default
```
root@treehouses:~/cli# ./cli.sh editor config default
vim config reset to default.
```

sections involving emacs is not yet implemented as emacs isn't included in builder yet