### PR TITLE
`treehouses sshtunnel remove port` external (fixes #1471)

### DIFF
--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -305,7 +305,7 @@ function sshtunnel {
           counter=1
           found=false
           while read -r line; do
-            if [[ $line =~ "-R $port:127.0.1.1" ]]; then
+            if [[ $line = *"-R $port:127.0.1.1"* ]]; then
               final=$counter
             fi
             if [ ! -z "$final" ] && [[ $line = *$host* ]]; then

--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -305,7 +305,7 @@ function sshtunnel {
           counter=1
           found=false
           while read -r line; do
-            if [[ $line =~ 127.0.1.1:$port ]]; then
+            if [[ $line =~ "-R $port:127.0.1.1" ]]; then
               final=$counter
             fi
             if [ ! -z "$final" ] && [[ $line = *$host* ]]; then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.22.14",
+  "version": "1.22.18",
   "remote": "2346",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Fixes #1471

* Filters by external ports instead of local ports when removing ports

* Fixes partial matching issues