### PR TITLE
`treehouses monitor` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ magazines                                 downloads specific magazine issue as a
    <wireframe>        [list]              lists downloaded magazines in tree format of specific magazine
 resolution <cea|dmt [modes]>              sets the screen resolution
 system [cpu|ram|disk|volt|temperature]    display real system informations
+monitor [start|log|notice]                monitor status of given url
 message gitter <apikey|sendto>            sends message to service or sets api/channel info in config file
 shutdown [now|in|force]                   shutdown the system
 ```

--- a/_treehouses
+++ b/_treehouses
@@ -227,6 +227,7 @@ treehouses memory used -g
 treehouses memory used -m
 treehouses message gitter apikey 
 treehouses message gitter sendto 
+treehouses monitor 
 treehouses networkmode
 treehouses networkmode info
 treehouses ntp internet

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -129,6 +129,7 @@ magazines                                 downloads specific magazine issue as a
    <wireframe>        [list]              lists downloaded magazines in tree format of specific magazine
 resolution <cea|dmt [modes]>              sets the screen resolution
 system [cpu|ram|disk|volt|temperature]    display real system informations
+monitor [start|log|notice]                monitor status of given url
 message gitter <apikey|sendto>            sends message to service or sets api/channel info in config file
 shutdown [now|in|force]                   shutdown the system
 EOF

--- a/modules/monitor.sh
+++ b/modules/monitor.sh
@@ -1,0 +1,73 @@
+function monitor {
+  checkroot
+  check_missing_packages "curl"
+  if [ -z $1 ]; then
+    monitor_help
+    exit 1
+  fi
+  
+  local url_regex ipv4_regex ipv6_regex file code
+  
+  url_regex='(https?|ftp|file)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]'
+  ipv4_regex='^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
+  ipv6_regex="^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))$"
+  if [[ ! $1 =~ $url_regex ]] && [[ ! $1 =~ $ipv4_regex ]] && [[ ! $1 =~ $ipv6_regex ]]; then
+    echo "Invalid url or ip address."
+    exit 1
+  fi 
+
+  if [ $# -eq 1 ]; then
+    curl -ILs -o /dev/null $1 -w "%{http_code}\n"
+    exit 0
+  fi
+
+  case "$2" in
+    start)
+      checkargn $# 2
+      watch -c -n 1 curl -ILs $1
+      echo "Monitoring for $1 terminated." && exit 0 ;;
+    log)
+      file="./log-$(echo "$1" | sed -e 's|^[^/]*//||' -e 's|/.*$||' -e 's|:.*$||')-$(date '+%Y-%m-%d_%H:%M:%S')"
+      if [ ! -z "$3" ]; then
+        checkargn $# 3
+        if [[ "$3" = */* ]]; then
+          mkdir -p "$(echo $3 | cut -d "/" -f "-$(awk -F"/" '{print NF-1}' <<< "${3}")")" 2>/dev/null
+        fi       
+        touch "$3"
+        file="$3"
+      fi
+      
+      echo "Monitoring for $1 started."
+      echo "Log file saving to $file."
+      echo "press (ctrl + c) to exit"
+      printf "\t\tDATE\t\t\tHTTP CODE\n" > "$file"
+
+      while :
+      do
+        code="$(curl -ILs -o /dev/null $1 -w "%{http_code}\n")" || break
+        printf "%s\t\t\t%s\n" "$(date '+%Y-%m-%d %H:%M:%S')" "$code" >> "$file"
+        sleep 5
+      done
+      echo "Unable to access $1." && exit 1 ;;
+    notice)
+      ;;
+    *)
+      echo "No option as $2."
+      monitor_help
+      exit 1 ;;
+  esac
+}
+
+function monitor_help {
+  echo
+  echo "Usage:  $BASENANE monitor <url> [start|log|notice]"
+  echo
+  echo "        $BASENAME monitor <url>          return http code of the url"
+  echo
+  echo "        $BASENAME monitor <url> start    start monitor various info of the url"
+  echo
+  echo "        $BASENAME monitor <url> log      start logging http code of the url with timestamp"
+  echo
+  echo "        $BASENAMe monitor <url> notice"
+  echo
+}


### PR DESCRIPTION
#1541 
```
root@treehouses:~# treehouses monitor https://google.com
200
```
```
root@treehouses:~# treehouses monitor https://freebsd.org log
Monitoring for https://freebsd.org started.
Log file saving to ./log-freebsd.org-2020-07-15_15:23:27.
press (ctrl + c) to exit
^C

root@treehouses:~# cat ./log-freebsd.org-2020-07-15_15\:23\:27
		DATE			HTTP CODE
2020-07-15 15:23:31			200
2020-07-15 15:23:39			200
```
```
root@treehouses:~# treehouses monitor https://treehouses.io start
Every 1.0s: curl -ILs https://treehouses.io                treehouses: Wed Jul 15 15:26:11 2020

HTTP/2 200
content-type: text/html; charset=utf-8
server: GitHub.com
last-modified: Fri, 10 Jul 2020 09:14:45 GMT
etag: "5f083185-62507"
access-control-allow-origin: *
expires: Wed, 15 Jul 2020 15:36:20 GMT
cache-control: max-age=600
x-proxy-cache: MISS
x-github-request-id: BD1E:0D9C:7FFDD:879E2:5F0F201C
accept-ranges: bytes
date: Wed, 15 Jul 2020 15:26:20 GMT
....
```