### PR TITLE
`treehouses upgrade bluetooth` targeted kill (fixes #1607)

### DIFF
--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -111,8 +111,8 @@ function bluetooth {
       ;;
 
     "restart")
-      bluetooth off &>"$LOGFILE"
-      bluetooth on &>"$LOGFILE"
+      (bluetooth off &>$LOGFILE && bluetooth on &>$LOGFILE) &>/dev/null &
+      #bluetooth on &>"$LOGFILE"
       echo "Success: the bluetooth service has been restarted."
       ;;
 

--- a/modules/bluetooth.sh
+++ b/modules/bluetooth.sh
@@ -111,8 +111,8 @@ function bluetooth {
       ;;
 
     "restart")
-      (bluetooth off &>$LOGFILE && bluetooth on &>$LOGFILE) &>/dev/null &
-      #bluetooth on &>"$LOGFILE"
+      bluetooth off &>"$LOGFILE"
+      bluetooth on &>"$LOGFILE"
       echo "Success: the bluetooth service has been restarted."
       ;;
 

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -43,7 +43,7 @@ function upgrade {
       fi
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    screen -dm bash -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart' &
+    screen -dm bash -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart' &>$LOGFILE"
     #cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     #curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
     #sleep 5

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -43,11 +43,7 @@ function upgrade {
       fi
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    screen -dm bash -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart' &>$LOGFILE
-    #cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    #curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
-    #sleep 5
-    #bluetooth restart
+    nohup (curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; bluetooth restart &>"$LOGFILE") &
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -43,9 +43,11 @@ function upgrade {
       fi
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
-    sleep 5
-    bluetooth restart
+    screen -dm bash -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart' &
+    #cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
+    #curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
+    #sleep 5
+    #bluetooth restart
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -43,7 +43,7 @@ function upgrade {
       fi
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    screen -dm sh -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; bluetooth restart' &
+    screen -dm sh -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart' &
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -44,8 +44,8 @@ function upgrade {
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py #&>/dev/null &
-    sleep 5 #&>/dev/null &
-    pkill -f server.py &>/dev/null &
+    #sleep 5 #&>/dev/null &
+    pkill -f server.py #&>/dev/null &
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -43,7 +43,7 @@ function upgrade {
       fi
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    nohup (curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; bluetooth restart &>"$LOGFILE") &
+    nohup sh -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; bluetooth restart &>"$LOGFILE")' > /dev/null &
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -45,6 +45,7 @@ function upgrade {
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
     if grep -q "Restart=always" /etc/systemd/system/rpibluetooth.service; then
+      echo "Killing Bluetooth Server"
       pkill -f bluetooth-server.py
     fi
     bluetooth restart &>"$LOGFILE"

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -42,10 +42,10 @@ function upgrade {
         log_and_exit1 "Error: branch specified not found on bluetooth server repository"
       fi
     fi
-    bluetooth off
+    kill $(pgrep -f 'python' | pgrep -f 'server.py')
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
-    bluetooth on &>"$LOGFILE"
+    bluetooth restart &>"$LOGFILE"
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -43,9 +43,9 @@ function upgrade {
       fi
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py #&>/dev/null &
-    #sleep 5 #&>/dev/null &
-    pkill -f server.py #&>/dev/null &
+    curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
+    pkill -f server.py
+    bluetooth restart &>"$LOGFILE"
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -42,10 +42,10 @@ function upgrade {
         log_and_exit1 "Error: branch specified not found on bluetooth server repository"
       fi
     fi
-    bluetooth stop
+    bluetooth off
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
-    bluetooth start &>"$LOGFILE"
+    bluetooth on &>"$LOGFILE"
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -43,7 +43,7 @@ function upgrade {
       fi
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    screen -dm bash -c "curl -s 'https://raw.githubusercontent.com/treehouses/control/${branch}/server.py' -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart" &
+    (curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart) &
     #cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     #curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
     #sleep 5

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -42,13 +42,13 @@ function upgrade {
         log_and_exit1 "Error: branch specified not found on bluetooth server repository"
       fi
     fi
-    bluetooth off
+    #bluetooth off
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     #screen -dm bash -c 'sleep 5; treehouses bluetooth off $> logfile'
     #bluetooth off
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
     sleep 5
-    bluetooth on
+    bluetooth restart
     #screen -dm bash -c 'sleep 5; treehouses bluetooth on $> logfile'
     #kill $(pgrep -f 'python' | pgrep -f 'server.py')
     echo "Successfully updated and restarted bluetooth server"

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -44,7 +44,9 @@ function upgrade {
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
-    pkill -f bluetooth-server.py
+    if grep -q "Restart=always" /etc/systemd/system/rpibluetooth.service; then
+      pkill -f bluetooth-server.py
+    fi
     bluetooth restart &>"$LOGFILE"
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -43,7 +43,7 @@ function upgrade {
       fi
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    screen -dm bash -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart' &>$LOGFILE"
+    screen -dm bash -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart' &>$LOGFILE
     #cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     #curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
     #sleep 5

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -42,15 +42,10 @@ function upgrade {
         log_and_exit1 "Error: branch specified not found on bluetooth server repository"
       fi
     fi
-    #bluetooth off
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    #screen -dm bash -c 'sleep 5; treehouses bluetooth off $> logfile'
-    #bluetooth off
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
     sleep 5
     bluetooth restart
-    #screen -dm bash -c 'sleep 5; treehouses bluetooth on $> logfile'
-    #kill $(pgrep -f 'python' | pgrep -f 'server.py')
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -43,7 +43,7 @@ function upgrade {
       fi
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    (curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart) &
+    screen -dm bash -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart' &
     #cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     #curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
     #sleep 5

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -42,10 +42,15 @@ function upgrade {
         log_and_exit1 "Error: branch specified not found on bluetooth server repository"
       fi
     fi
-    kill $(pgrep -f 'python' | pgrep -f 'server.py')
+    bluetooth off
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
+    #screen -dm bash -c 'sleep 5; treehouses bluetooth off $> logfile'
+    #bluetooth off
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
-    bluetooth restart &>"$LOGFILE"
+    sleep 5
+    bluetooth on
+    #screen -dm bash -c 'sleep 5; treehouses bluetooth on $> logfile'
+    #kill $(pgrep -f 'python' | pgrep -f 'server.py')
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -43,7 +43,7 @@ function upgrade {
       fi
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    nohup sh -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; bluetooth restart &>"$LOGFILE")' > /dev/null &
+    nohup sh -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; bluetooth restart &>"$LOGFILE"' > /dev/null &
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -44,7 +44,7 @@ function upgrade {
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
-    pkill -f server.py
+    pkill -f bluetooth-server.py
     bluetooth restart &>"$LOGFILE"
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -44,6 +44,7 @@ function upgrade {
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
+    # hacky but necessary
     if grep -q "Restart=always" /etc/systemd/system/rpibluetooth.service; then
       pkill -f bluetooth-server.py
     fi

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -43,7 +43,7 @@ function upgrade {
       fi
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    screen -dm bash -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart' &
+    screen -dm bash -c "curl -s 'https://raw.githubusercontent.com/treehouses/control/${branch}/server.py' -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart" &
     #cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     #curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
     #sleep 5

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -45,7 +45,7 @@ function upgrade {
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py #&>/dev/null &
     sleep 5 #&>/dev/null &
-    (bluetooth restart &>$LOGFILE) &>/dev/null &
+    pkill -f server.py &>/dev/null &
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -43,7 +43,7 @@ function upgrade {
       fi
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    nohup sh -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; bluetooth restart &>"$LOGFILE"' > /dev/null &
+    screen -dm sh -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; bluetooth restart' &
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -45,7 +45,6 @@ function upgrade {
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
     if grep -q "Restart=always" /etc/systemd/system/rpibluetooth.service; then
-      echo "Killing Bluetooth Server"
       pkill -f bluetooth-server.py
     fi
     bluetooth restart &>"$LOGFILE"

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -43,7 +43,9 @@ function upgrade {
       fi
     fi
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
-    screen -dm sh -c 'curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py; sleep 5; bluetooth restart' &
+    curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py #&>/dev/null &
+    sleep 5 #&>/dev/null &
+    (bluetooth restart &>$LOGFILE) &>/dev/null &
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -45,7 +45,7 @@ function upgrade {
     bluetooth stop
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
-    bluetooth restart &>"$LOGFILE"
+    bluetooth start &>"$LOGFILE"
     echo "Successfully updated and restarted bluetooth server"
   elif [ "$tag" == "cli" ]; then
     checkroot

--- a/modules/upgrade.sh
+++ b/modules/upgrade.sh
@@ -42,6 +42,7 @@ function upgrade {
         log_and_exit1 "Error: branch specified not found on bluetooth server repository"
       fi
     fi
+    bluetooth stop
     cp /usr/local/bin/bluetooth-server.py "/usr/local/bin/bluetooth-server.py.$(date +'%Y%m%d%H%m%S')"
     curl -s "https://raw.githubusercontent.com/treehouses/control/${branch}/server.py" -o /usr/local/bin/bluetooth-server.py
     bluetooth restart &>"$LOGFILE"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.23.25",
+  "version": "1.23.45",
   "remote": "2500",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
improves the bluetooth upgrade function to work when sent from remote. requires an up to date treehouses image, or make sure your rpibluetooth service is the same as master https://github.com/treehouses/builder/blob/master/install/etc/systemd/system/rpibluetooth.service

- fixes #1607