### PR TITLE
`treehouses memory` fixed from `-g, -m` to `gb, mb` (fixes #1671)

### DIFF
--- a/_treehouses
+++ b/_treehouses
@@ -214,17 +214,17 @@ treehouses magazines available
 treehouses magazines downloaded
 $(magazines_cmds)
 treehouses memory
-treehouses memory -g
-treehouses memory -m
+treehouses memory gb
+treehouses memory mb
 treehouses memory free
-treehouses memory free -g
-treehouses memory free -m
+treehouses memory free gb
+treehouses memory free mb
 treehouses memory total
-treehouses memory total -g
-treehouses memory total -m
+treehouses memory total gb
+treehouses memory total mb
 treehouses memory used
-treehouses memory used -g
-treehouses memory used -m
+treehouses memory used gb
+treehouses memory used mb
 treehouses message gitter apikey 
 treehouses message gitter sendto 
 treehouses networkmode

--- a/modules/memory.sh
+++ b/modules/memory.sh
@@ -12,7 +12,7 @@ function memory_total() {
       t=$(free | grep -i Mem | awk '{printf $2}')
       ;;
     *)
-      echo "error: only '-g' and '-m' argument accepted (check 'treehouses help memory')"
+      echo "error: only 'gb' and 'mb' argument accepted (check 'treehouses help memory')"
       exit 1
       ;;
   esac


### PR DESCRIPTION
This fixes issue #1671