### PR TITLE
`treehouses memory` no dash outputs (fixes #1671)

### DIFF
--- a/modules/memory.sh
+++ b/modules/memory.sh
@@ -12,7 +12,7 @@ function memory_total() {
       t=$(free | grep -i Mem | awk '{printf $2}')
       ;;
     *)
-      echo "error: only '-g' and '-m' argument accepted (check 'treehouses help memory')"
+      echo "error: only 'gb' and 'mb' argument accepted (check 'treehouses help memory')"
       exit 1
       ;;
   esac

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.23.35",
-  "remote": "2500",
+  "version": "1.23.36",
+  "remote": "3000",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",
   "bin": {


### PR DESCRIPTION
This fixes issue #1671
