### PR TITLE
`treehouses services pylon` with env (fixes #1682)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.23.36",
+  "version": "1.23.42",
   "remote": "3000",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",

--- a/services/install-pylon.sh
+++ b/services/install-pylon.sh
@@ -23,8 +23,8 @@ EOF
 
   # create .env with default values
   cat << EOF > /srv/pylon/.env
-"PYUSER=<username>"
-"PYPASS=<password>"
+PYUSER=<username>
+PYPASS=<password>
 EOF
 
   # add autorun


### PR DESCRIPTION
Fixes #1682
Testing part 1 is mainly making sure nothing is broken.
Testing part 2 is making sure `treehouses services config edit request` and `treehouses services config edit send` now work for pylon. 
## Testing Part 1
1. Run `./cli.sh services pylon cleanup` if pylon is already installed.
2. Run `./cli.sh services pylon install`.
3. Run `./cli.sh services pylon up`.
4. Run `./cli.sh services pylon url` and use the first url in browser to run pylon.
5. Check to see if app still asks for username and password and then enter \<username> for username and \<password> for password.
6. You should now be able to use the app.
![2020-07-18](https://user-images.githubusercontent.com/44847682/87867106-576ae500-c93e-11ea-886f-3a5e9ec3069f.png)


## Testing Part 2
1. To make sure I fixed the issue, run `./cli.sh services pylon down` if it is still running.
2. Run `./cli.sh services pylon config edit request` and copy the output.
3. Paste that (change cli.sh to ./cli.sh) and replace the default values in the quotes with new username and password. Run it.
4. Run `./cli.sh services pylon up` and load pylon in a new browser or incognito mode (to make sure it asks for username and password again) and see if it asks for your new username and password and if they work.
![2020-07-18 (1)](https://user-images.githubusercontent.com/44847682/87867295-62267980-c940-11ea-94db-57b9bacf3f80.png)
