### PR TITLE
`treehouses ssh 2fa` (fixes #1646)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ apchannel [channel]                       sets or prints the current ap channel
 timezone <timezone>                       sets the timezone of the system
 locale <locale>                           sets the system locale
 ssh [on|off|fingerprint]                  enables or disables the ssh service,
-    [2fa] <add|enable|disable>            also prints out fingerprint of the ssh daemon
+    [2fa] <add|enable|disable|remove>     also prints out fingerprint of the ssh daemon
 vnc [on|off|info]                         enables or disables the vnc server service
 default [network|notice|tunnel]           sets a raspbian back to default configuration
 wificountry <country>                     sets the wifi country

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ aphidden <local|internet> <ESSID>         creates a hidden mobile ap with or wit
 apchannel [channel]                       sets or prints the current ap channel
 timezone <timezone>                       sets the timezone of the system
 locale <locale>                           sets the system locale
-ssh [on|off|fingerprint]                  enables or disables the ssh service, also prints out fingerprint of the ssh daemon
+ssh [on|off|fingerprint]                  enables or disables the ssh service,
+    [2fa] <add|enable|disable>            also prints out fingerprint of the ssh daemon
 vnc [on|off|info]                         enables or disables the vnc server service
 default [network|notice|tunnel]           sets a raspbian back to default configuration
 wificountry <country>                     sets the wifi country

--- a/_treehouses
+++ b/_treehouses
@@ -306,6 +306,10 @@ treehouses shutdown force
 treehouses speedtest
 treehouses speedtest -h
 treehouses ssh
+treehouses ssh 2fa
+treehouses ssh 2fa add
+treehouses ssh 2fa disable
+treehouses ssh 2fa enable
 treehouses ssh fingerprint
 treehouses ssh off
 treehouses ssh on

--- a/_treehouses
+++ b/_treehouses
@@ -310,6 +310,7 @@ treehouses ssh 2fa
 treehouses ssh 2fa add
 treehouses ssh 2fa disable
 treehouses ssh 2fa enable
+treehouses ssh 2fa remove
 treehouses ssh fingerprint
 treehouses ssh off
 treehouses ssh on

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -38,7 +38,7 @@ apchannel [channel]                       sets or prints the current ap channel
 timezone <timezone>                       sets the timezone of the system
 locale <locale>                           sets the system locale
 ssh [on|off|fingerprint]                  enables or disables the ssh service,
-    [2fa] <add|enable|disable>            also prints out fingerprint of the ssh daemon
+    [2fa] <add|enable|disable|remove>     also prints out fingerprint of the ssh daemon
 vnc [on|off|info]                         enables or disables the vnc server service
 default [network|notice|tunnel]           sets a raspbian back to default configuration
 wificountry <country>                     sets the wifi country

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -37,7 +37,8 @@ aphidden <local|internet> <ESSID>         creates a hidden mobile ap with or wit
 apchannel [channel]                       sets or prints the current ap channel
 timezone <timezone>                       sets the timezone of the system
 locale <locale>                           sets the system locale
-ssh [on|off|fingerprint]                  enables or disables the ssh service, also prints out fingerprint of the ssh daemon
+ssh [on|off|fingerprint]                  enables or disables the ssh service,
+    [2fa] <add|enable|disable>            also prints out fingerprint of the ssh daemon
 vnc [on|off|info]                         enables or disables the vnc server service
 default [network|notice|tunnel]           sets a raspbian back to default configuration
 wificountry <country>                     sets the wifi country

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -34,7 +34,12 @@ function ssh {
           elif cut -d: -f1 /etc/passwd | grep -q "$3"; then
             if [ "$2" == "add" ]; then
               echo "Adding 2FA for user $3..."
-              runuser -l "$3" -c "google-authenticator"
+              if [ "$4" == "default" ]; then
+                printf "y\ny\nn\ny\ny\n" | runuser -l "$3" -c "google-authenticator" |\
+                  grep -o -E "https://.*$"
+              else
+                runuser -l "$3" -c "google-authenticator"
+              fi
               if [ ! -f "/home/$3/.google_authenticator" ]; then
                 echo "Addtion for $3 user failed"
                 exit 1
@@ -95,6 +100,9 @@ function ssh_help {
   echo
   echo "  $BASENAME ssh 2FA add/remove <user>"
   echo "      Add/Remove a user for SSH with two factor authentication."
+  echo
+  echo "  $BASENAME ssh 2FA add <user> default"
+  echo "      Add a user but with non-interactive mode and preset config."
   echo
   echo "  $BASENAME ssh 2FA enable/disable"
   echo "      Enable/Disable two factor authentication for SSH service."

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -100,10 +100,10 @@ function ssh_help {
   echo "  $BASENAME ssh fingerprint"
   echo "      The SSH fingerprint will be printed from when the session was first established."
   echo
-  echo "  $BASENAME ssh 2FA add/remove <user> [url|interactive]"
+  echo "  $BASENAME ssh 2fa add/remove <user> [url|interactive]"
   echo "      Add/Remove a user for SSH with two factor authentication."
   echo
-  echo "  $BASENAME ssh 2FA enable/disable"
+  echo "  $BASENAME ssh 2fa enable/disable"
   echo "      Enable/Disable two factor authentication for SSH service."
   echo
 }

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -65,7 +65,7 @@ function ssh {
           echo "ssh Two Factor Authentication enabled."
           ;;
         "disable")
-          sed -i 's/auth required pam_google_authenticator.so nullok//g' /etc/pam.d/sshd
+          sed -i '\:auth required pam_google_authenticator.so nullok:d' /etc/pam.d/sshd
           sed -i 's/ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/g' /etc/ssh/sshd_config
           restart_service sshd
           echo "ssh Two Factor Authentication disabled."

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -25,20 +25,24 @@ function ssh {
     "2fa" | "2FA")
       check_missing_packages "libpam-google-authenticator"
       case "$2" in
-        "add")
+        "add" | "remove")
           if [ -z "$3" ]; then
-            echo "Please specify the user to enable 2FA."
+            echo "Please specify the user."
           elif [ "$3" == "root" ]; then
-            echo "You can't enable 2FA for root user."
+            echo "You can't add or remove 2FA for root user."
             echo "You should only login as root user via a ssh key."
           elif cut -d: -f1 /etc/passwd | grep -q "$3"; then
-            echo "Adding 2FA for user $3..."
-            runuser -l "$3" -c "google-authenticator"
-            if [ ! -f "/home/$3/.google_authenticator" ]; then
-              echo "Addtion for $3 user failed"
-              exit 1
+            if [ "$2" == "add" ]; then
+              echo "Adding 2FA for user $3..."
+              runuser -l "$3" -c "google-authenticator"
+              if [ ! -f "/home/$3/.google_authenticator" ]; then
+                echo "Addtion for $3 user failed"
+                exit 1
+              fi
+              ssh 2fa enable
+            else
+              rm -rf "/home/$3/.google_authenticator"
             fi
-            ssh 2fa enable
             exit 0
           else
             echo "No user as $3 found."
@@ -89,13 +93,10 @@ function ssh_help {
   echo "  $BASENAME ssh fingerprint"
   echo "      The SSH fingerprint will be printed from when the session was first established."
   echo
-  echo "  $BASENAME ssh 2FA add <user>"
-  echo "      Add a user for SSH with two factor authentication."
+  echo "  $BASENAME ssh 2FA add/remove <user>"
+  echo "      Add/Remove a user for SSH with two factor authentication."
   echo
-  echo "  $BASENAME ssh 2FA enable"
-  echo "      Enable two factor authentication for SSH service."
-  echo
-  echo "  $BASENAME ssh 2FA disable"
-  echo "      Disable two factor authentication for SSH service."
+  echo "  $BASENAME ssh 2FA enable/disable"
+  echo "      Enable/Disable two factor authentication for SSH service."
   echo
 }

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -49,8 +49,8 @@ function ssh {
           fi
           exit 1 ;;
         "enable")
-          if ! grep -q "auth required pam_google_authenticator.so" /etc/pam.d/sshd; then
-            echo "auth required pam_google_authenticator.so" >> /etc/pam.d/sshd
+          if ! grep -q "auth required pam_google_authenticator.so nullok" /etc/pam.d/sshd; then
+            echo "auth required pam_google_authenticator.so nullok" >> /etc/pam.d/sshd
           fi
           sed -i 's/ChallengeResponseAuthentication no/ChallengeResponseAuthentication yes/g' /etc/ssh/sshd_config
           restart_service sshd
@@ -58,7 +58,7 @@ function ssh {
           echo "ssh Two Factor Authentication enabled."
           ;;
         "disable")
-          sed -i 's/auth required pam_google_authenticator.so//g' /etc/pam.d/sshd
+          sed -i 's/auth required pam_google_authenticator.so nullok//g' /etc/pam.d/sshd
           sed -i 's/ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/g' /etc/ssh/sshd_config
           restart_service sshd
           echo "ssh Two Factor Authentication disabled."

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -33,18 +33,20 @@ function ssh {
             echo "You should only login as root user via a ssh key."
           elif cut -d: -f1 /etc/passwd | grep -q "$3"; then
             if [ "$2" == "add" ]; then
-              echo "Adding 2FA for user $3..."
-              if [ "$4" == "default" ]; then
+              if [ "$4" == "url" ]; then
                 printf "y\ny\nn\ny\ny\n" | runuser -l "$3" -c "google-authenticator" |\
                   grep -o -E "https://.*$"
-              else
+              elif [ "$4" == "interactive" ]; then
                 runuser -l "$3" -c "google-authenticator"
+              else
+                echo "Adding 2FA for user $3..."
+                printf "y\ny\nn\ny\ny\n" | runuser -l "$3" -c "google-authenticator"
               fi
               if [ ! -f "/home/$3/.google_authenticator" ]; then
                 echo "Addtion for $3 user failed"
                 exit 1
               fi
-              ssh 2fa enable
+              ssh 2fa enable > /dev/null
             else
               rm -rf "/home/$3/.google_authenticator"
             fi
@@ -98,11 +100,8 @@ function ssh_help {
   echo "  $BASENAME ssh fingerprint"
   echo "      The SSH fingerprint will be printed from when the session was first established."
   echo
-  echo "  $BASENAME ssh 2FA add/remove <user>"
+  echo "  $BASENAME ssh 2FA add/remove <user> [url|interactive]"
   echo "      Add/Remove a user for SSH with two factor authentication."
-  echo
-  echo "  $BASENAME ssh 2FA add <user> default"
-  echo "      Add a user but with non-interactive mode and preset config."
   echo
   echo "  $BASENAME ssh 2FA enable/disable"
   echo "      Enable/Disable two factor authentication for SSH service."

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -1,25 +1,69 @@
 function ssh {
   local status
   checkroot
-  checkargn $# 1
   status=$1
   case $status in
     "on")
+      checkargn $# 1
       enable_service ssh
       start_service ssh
       echo "Success: the ssh service has been started and enabled when the system boots"
       ;;
     "off")
+      checkargn $# 1
       disable_service ssh
       stop_service ssh
       echo "Success: the ssh service has been stopped and disabled when the system boots."
       ;;
     "fingerprint")
+      checkargn $# 1
       ssh-keygen -l -E sha256 -f /etc/ssh/ssh_host_ecdsa_key.pub | cut -c5-54
       ;;
     "")
       last | grep -E "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b"
       ;;
+    "2fa" | "2FA")
+      check_missing_packages "libpam-google-authenticator"
+      case "$2" in
+        "add")
+          if [ -z "$3" ]; then
+            echo "Please specify the user to enable 2FA."
+          elif [ "$3" == "root" ]; then
+            echo "You can't enable 2FA for root user."
+            echo "You should only login as root user via a ssh key."
+          elif cut -d: -f1 /etc/passwd | grep -q "$3"; then
+            echo "Adding 2FA for user $3..."
+            runuser -l "$3" -c "google-authenticator"
+            if [ ! -f "/home/$3/.google_authenticator" ]; then
+              echo "Addtion for $3 user failed"
+              exit 1
+            fi
+            ssh 2fa enable
+            exit 0
+          else
+            echo "No user as $3 found."
+          fi
+          exit 1 ;;
+        "enable")
+          if ! grep -q "auth required pam_google_authenticator.so" /etc/pam.d/sshd; then
+            echo "auth required pam_google_authenticator.so" >> /etc/pam.d/sshd
+          fi
+          sed -i 's/ChallengeResponseAuthentication no/ChallengeResponseAuthentication yes/g' /etc/ssh/sshd_config
+          restart_service sshd
+          enable_service sshd
+          echo "ssh Two Factor Authentication enabled."
+          ;;
+        "disable")
+          sed -i 's/auth required pam_google_authenticator.so//g' /etc/pam.d/sshd
+          sed -i 's/ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/g' /etc/ssh/sshd_config
+          restart_service sshd
+          echo "ssh Two Factor Authentication disabled."
+          ;;
+        *)
+          ssh_help
+          ;;
+      esac
+      exit 0 ;;
     *)
       echo "Error: only '', 'on', 'off', or 'fingerprint' options are supported"
       ;;
@@ -44,5 +88,14 @@ function ssh_help {
   echo 
   echo "  $BASENAME ssh fingerprint"
   echo "      The SSH fingerprint will be printed from when the session was first established."
+  echo
+  echo "  $BASENAME ssh 2FA add <user>"
+  echo "      Add a user for SSH with two factor authentication."
+  echo
+  echo "  $BASENAME ssh 2FA enable"
+  echo "      Enable two factor authentication for SSH service."
+  echo
+  echo "  $BASENAME ssh 2FA disable"
+  echo "      Disable two factor authentication for SSH service."
   echo
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.23.39",
+  "version": "1.23.74",
   "remote": "3000",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
fixes #1646

---

## how to test

Enable 2fa for ssh:
```
$ treehouses ssh 2fa enable
```

then set up pi user for 2fa:
```
$ treehouses ssh 2fa add pi
```
follow it step by step, scan the qr code on your phone

Next time try ssh **without** a ssh key, you'll be prompted with:
```
Password: 
Verification code: 
```

You can use `ssh -i ./ pi@....` to use an invalid file as key, this has the same effect of not using a key at all.