### PR TITLE
` treehouses message gitter send|receive` (fixes #1700)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,7 @@ magazines                                 downloads specific magazine issue as a
                       [url]               shows the homepage URL of magazine
 resolution <cea|dmt [modes]>              sets the screen resolution
 system [cpu|ram|disk|volt|temperature]    display real system informations
-message gitter <apikey|sendto>            sends message to service or sets api/channel info in config file
-               receivefrom read 
-                           meark-read
+message gitter <apikey|send|recieve>      sets api/channel info in config file and sends/recieves message
 shutdown [now|in|force]                   shutdown the system
 ```
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ magazines                                 downloads specific magazine issue as a
 resolution <cea|dmt [modes]>              sets the screen resolution
 system [cpu|ram|disk|volt|temperature]    display real system informations
 message gitter <apikey|sendto>            sends message to service or sets api/channel info in config file
-               <receivefrom>
+               receivefrom read 
+                           meark-read
 shutdown [now|in|force]                   shutdown the system
 ```
 

--- a/_treehouses
+++ b/_treehouses
@@ -227,9 +227,9 @@ treehouses memory used
 treehouses memory used gb
 treehouses memory used mb
 treehouses message gitter apikey
-treehouses message gitter sendto
-treehouses message gitter receivefrom read
-treehouses message gitter receivefrom mark-read
+treehouses message gitter send
+treehouses message gitter receive read
+treehouses message gitter receive mark
 treehouses networkmode
 treehouses networkmode info
 treehouses ntp internet

--- a/_treehouses
+++ b/_treehouses
@@ -228,7 +228,8 @@ treehouses memory used gb
 treehouses memory used mb
 treehouses message gitter apikey
 treehouses message gitter sendto
-treehouses message gitter receivefrom
+treehouses message gitter receivefrom read
+treehouses message gitter receivefrom mark-read
 treehouses networkmode
 treehouses networkmode info
 treehouses ntp internet

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -134,7 +134,8 @@ magazines                                 downloads specific magazine issue as a
 resolution <cea|dmt [modes]>              sets the screen resolution
 system [cpu|ram|disk|volt|temperature]    display real system informations
 message gitter <apikey|sendto>            sends message to service or sets api/channel info in config file
-               <receivefrom>
+               receivefrom read 
+                           meark-read
 shutdown [now|in|force]                   shutdown the system
 EOF
   echo "$helpdefault"

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -133,9 +133,7 @@ magazines                                 downloads specific magazine issue as a
                       [url]               shows the homepage URL of magazine
 resolution <cea|dmt [modes]>              sets the screen resolution
 system [cpu|ram|disk|volt|temperature]    display real system informations
-message gitter <apikey|sendto>            sends message to service or sets api/channel info in config file
-               receivefrom read 
-                           meark-read
+message gitter <apikey|send|recieve>      sets api/channel info in config file and sends/recieves message
 shutdown [now|in|force]                   shutdown the system
 EOF
   echo "$helpdefault"

--- a/modules/message.sh
+++ b/modules/message.sh
@@ -100,7 +100,7 @@ function message {
 
 function message_help {
   echo
-  echo "Usage: $BASENAME message <chats> <apikey <key> | sendto <group> <message> | receivefrom read|mark-read <group>>"
+  echo "Usage: $BASENAME message <chats> <apikey <key> | send <group> <message> | receive read|mark <group>>"
   echo
   echo "You can get your token from https://developer.gitter.im/docs/welcome by signing in, it should show up immediately or by navigating to https://developer.gitter.im/apps"
   echo

--- a/modules/message.sh
+++ b/modules/message.sh
@@ -116,10 +116,10 @@ function message_help {
   echo "  $BASENAME message gitter sendto treehouses/Lobby \"Hi, you are very awesome\""
   echo "     Sends a message to a gitter channel"
   echo
-  echo "  $BASENAME message gitter receivefrom read treehouses/Lobby" 
+  echo "  $BASENAME message gitter receivefrom read treehouses/Lobby"
   echo "     Receives and displays unread messages from a gitter channel"
   echo
-  echo "  $BASENAME message gitter receivefrom mark-read treehouses/Lobby" 
+  echo "  $BASENAME message gitter receivefrom mark-read treehouses/Lobby"
   echo "     Marks unread messages from a gitter channel to read"
   echo
 }

--- a/modules/message.sh
+++ b/modules/message.sh
@@ -11,7 +11,7 @@ function message {
           token_info=$(echo $api_info | python -m json.tool | jq '.access_token' | tr -d '"')
           conf_var_update "api_token" "$token_info"
           ;;
-        sendto)
+        send)
           #joins room
           group="$3"
           curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms" -d '{"uri":"'$group'"}'>"$LOGFILE"
@@ -29,7 +29,7 @@ function message {
             echo "No message was submitted."
           fi
           ;;
-        receivefrom)
+        receive)
           case "$3" in
             read)
               group="$4"
@@ -59,7 +59,7 @@ function message {
                 i=$((i+1))
               done
               ;;
-            mark-read)
+            mark)
               group="$4"
               curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms" -d '{"uri":"'$group'"}'>"$LOGFILE"
               channelinfo=$(curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms" -d '{"uri":"'$group'"}')
@@ -113,13 +113,13 @@ function message_help {
   echo "  $BASENAME message gitter apikey \"1234567890\""
   echo "     Sets and saves API token"
   echo
-  echo "  $BASENAME message gitter sendto treehouses/Lobby \"Hi, you are very awesome\""
+  echo "  $BASENAME message gitter send treehouses/Lobby \"Hi, you are very awesome\""
   echo "     Sends a message to a gitter channel"
   echo
-  echo "  $BASENAME message gitter receivefrom read treehouses/Lobby"
+  echo "  $BASENAME message gitter receive read treehouses/Lobby"
   echo "     Receives and displays unread messages from a gitter channel"
   echo
-  echo "  $BASENAME message gitter receivefrom mark-read treehouses/Lobby"
+  echo "  $BASENAME message gitter receive mark treehouses/Lobby"
   echo "     Marks unread messages from a gitter channel to read"
   echo
 }

--- a/modules/message.sh
+++ b/modules/message.sh
@@ -56,7 +56,6 @@ function message {
                 echo "From: $from_name@$from_user"
                 echo "Message: $message"
                 echo "Sent: $sent_time"
-               # curl -X POST -s -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems" -d '{"chat":["'$message_id'"]}' > "$LOGFILE"
                 i=$((i+1))
               done
               ;;
@@ -76,48 +75,10 @@ function message {
               unread_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems")
               while [ "$i" -lt $length ]; do
                 message_id=$(echo $unread_info | python -m json.tool | jq '.chat['$i']' | tr -d '"')
-              #  message_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms/$channelid/chatMessages/$message_id")
-              #  message=$(echo $message_info | python -m json.tool | jq '.text')
-              #  from_name=$(echo $message_info | python -m json.tool | jq '.fromUser.displayName' | tr -d '"')
-              #  from_user=$(echo $message_info | python -m json.tool | jq '.fromUser.username' | tr -d '"') 
-              #  sent_time=$(echo $message_info | python -m json.tool | jq '.sent' | tr -d '"')  
-                #displays message
-              #  echo "From: $from_name@$from_user"
-              #  echo "Message: $message"
-              #  echo "Sent: $sent_time"
                 curl -X POST -s -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems" -d '{"chat":["'$message_id'"]}' > "$LOGFILE"
                 i=$((i+1))
               done
               ;;
-      
-         # group="$3"
-         # curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms" -d '{"uri":"'$group'"}'>"$LOGFILE"
-         # channelinfo=$(curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms" -d '{"uri":"'$group'"}')
-          #finds channel id and removes double quotes
-         # channelid=$(echo $channelinfo | python -m json.tool | jq '.id' | tr -d '"')
-         # user_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user")
-         # user_id=$(echo $user_info | python -m json.tool | jq '.[].id' | tr -d '"')
-         # i=0
-         # length=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems" | python -m json.tool | jq '.chat | length')
-         # if [ $length == 0 ];then
-           # echo "You have no unread messages at the moment"
-         # fi
-         # unread_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems")
-         # while [ "$i" -lt $length ]; do
-           # message_id=$(echo $unread_info | python -m json.tool | jq '.chat['$i']' | tr -d '"')
-           # message_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms/$channelid/chatMessages/$message_id")
-           # message=$(echo $message_info | python -m json.tool | jq '.text')
-           # from_name=$(echo $message_info | python -m json.tool | jq '.fromUser.displayName' | tr -d '"')
-           # from_user=$(echo $message_info | python -m json.tool | jq '.fromUser.username' | tr -d '"') 
-           # sent_time=$(echo $message_info | python -m json.tool | jq '.sent' | tr -d '"')  
-            #displays message
-           # echo "From: $from_name@$from_user"
-           # echo "Message: $message"
-           # echo "Sent: $sent_time"
-           # curl -X POST -s -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems" -d '{"chat":["'$message_id'"]}' > "$LOGFILE"
-           # i=$((i+1))
-         # done
-         # ;;
             *)
               echo "This command does not exist, please look at the following:"
               message_help

--- a/modules/message.sh
+++ b/modules/message.sh
@@ -30,33 +30,99 @@ function message {
           fi
           ;;
         receivefrom)
-          group="$3"
-          curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms" -d '{"uri":"'$group'"}'>"$LOGFILE"
-          channelinfo=$(curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms" -d '{"uri":"'$group'"}')
+          case "$3" in
+            read)
+              group="$4"
+              curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms" -d '{"uri":"'$group'"}'>"$LOGFILE"
+              channelinfo=$(curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms" -d '{"uri":"'$group'"}')
+              #finds channel id and removes double quotes
+              channelid=$(echo $channelinfo | python -m json.tool | jq '.id' | tr -d '"')
+              user_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user")
+              user_id=$(echo $user_info | python -m json.tool | jq '.[].id' | tr -d '"')
+              i=0
+              length=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems" | python -m json.tool | jq '.chat | length')
+              if [ $length == 0 ];then
+                echo "You have no unread messages at the moment"
+              fi
+              unread_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems")
+              while [ "$i" -lt $length ]; do
+                message_id=$(echo $unread_info | python -m json.tool | jq '.chat['$i']' | tr -d '"')
+                message_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms/$channelid/chatMessages/$message_id")
+                message=$(echo $message_info | python -m json.tool | jq '.text')
+                from_name=$(echo $message_info | python -m json.tool | jq '.fromUser.displayName' | tr -d '"')
+                from_user=$(echo $message_info | python -m json.tool | jq '.fromUser.username' | tr -d '"') 
+                sent_time=$(echo $message_info | python -m json.tool | jq '.sent' | tr -d '"')  
+                #displays message
+                echo "From: $from_name@$from_user"
+                echo "Message: $message"
+                echo "Sent: $sent_time"
+               # curl -X POST -s -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems" -d '{"chat":["'$message_id'"]}' > "$LOGFILE"
+                i=$((i+1))
+              done
+              ;;
+            mark-read)
+              group="$4"
+              curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms" -d '{"uri":"'$group'"}'>"$LOGFILE"
+              channelinfo=$(curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms" -d '{"uri":"'$group'"}')
+              #finds channel id and removes double quotes
+              channelid=$(echo $channelinfo | python -m json.tool | jq '.id' | tr -d '"')
+              user_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user")
+              user_id=$(echo $user_info | python -m json.tool | jq '.[].id' | tr -d '"')
+              i=0
+              length=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems" | python -m json.tool | jq '.chat | length')
+              if [ $length == 0 ];then
+                echo "You have no unread messages at the moment"
+              fi
+              unread_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems")
+              while [ "$i" -lt $length ]; do
+                message_id=$(echo $unread_info | python -m json.tool | jq '.chat['$i']' | tr -d '"')
+              #  message_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms/$channelid/chatMessages/$message_id")
+              #  message=$(echo $message_info | python -m json.tool | jq '.text')
+              #  from_name=$(echo $message_info | python -m json.tool | jq '.fromUser.displayName' | tr -d '"')
+              #  from_user=$(echo $message_info | python -m json.tool | jq '.fromUser.username' | tr -d '"') 
+              #  sent_time=$(echo $message_info | python -m json.tool | jq '.sent' | tr -d '"')  
+                #displays message
+              #  echo "From: $from_name@$from_user"
+              #  echo "Message: $message"
+              #  echo "Sent: $sent_time"
+                curl -X POST -s -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems" -d '{"chat":["'$message_id'"]}' > "$LOGFILE"
+                i=$((i+1))
+              done
+              ;;
+      
+         # group="$3"
+         # curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms" -d '{"uri":"'$group'"}'>"$LOGFILE"
+         # channelinfo=$(curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms" -d '{"uri":"'$group'"}')
           #finds channel id and removes double quotes
-          channelid=$(echo $channelinfo | python -m json.tool | jq '.id' | tr -d '"')
-          user_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user")
-          user_id=$(echo $user_info | python -m json.tool | jq '.[].id' | tr -d '"')
-          i=0
-          length=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems" | python -m json.tool | jq '.chat | length')
-          if [ $length == 0 ];then
-            echo "You have no unread messages at the moment"
-          fi
-          unread_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems")
-          while [ "$i" -lt $length ]; do
-            message_id=$(echo $unread_info | python -m json.tool | jq '.chat['$i']' | tr -d '"')
-            message_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms/$channelid/chatMessages/$message_id")
-            message=$(echo $message_info | python -m json.tool | jq '.text')
-            from_name=$(echo $message_info | python -m json.tool | jq '.fromUser.displayName' | tr -d '"')
-            from_user=$(echo $message_info | python -m json.tool | jq '.fromUser.username' | tr -d '"') 
-            sent_time=$(echo $message_info | python -m json.tool | jq '.sent' | tr -d '"')  
+         # channelid=$(echo $channelinfo | python -m json.tool | jq '.id' | tr -d '"')
+         # user_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user")
+         # user_id=$(echo $user_info | python -m json.tool | jq '.[].id' | tr -d '"')
+         # i=0
+         # length=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems" | python -m json.tool | jq '.chat | length')
+         # if [ $length == 0 ];then
+           # echo "You have no unread messages at the moment"
+         # fi
+         # unread_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems")
+         # while [ "$i" -lt $length ]; do
+           # message_id=$(echo $unread_info | python -m json.tool | jq '.chat['$i']' | tr -d '"')
+           # message_info=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/rooms/$channelid/chatMessages/$message_id")
+           # message=$(echo $message_info | python -m json.tool | jq '.text')
+           # from_name=$(echo $message_info | python -m json.tool | jq '.fromUser.displayName' | tr -d '"')
+           # from_user=$(echo $message_info | python -m json.tool | jq '.fromUser.username' | tr -d '"') 
+           # sent_time=$(echo $message_info | python -m json.tool | jq '.sent' | tr -d '"')  
             #displays message
-            echo "From: $from_name@$from_user"
-            echo "Message: $message"
-            echo "Sent: $sent_time"
-            curl -X POST -s -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems" -d '{"chat":["'$message_id'"]}' > "$LOGFILE"
-            i=$((i+1))
-          done
+           # echo "From: $from_name@$from_user"
+           # echo "Message: $message"
+           # echo "Sent: $sent_time"
+           # curl -X POST -s -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $api_token" "https://api.gitter.im/v1/user/$user_id/rooms/$channelid/unreadItems" -d '{"chat":["'$message_id'"]}' > "$LOGFILE"
+           # i=$((i+1))
+         # done
+         # ;;
+            *)
+              echo "This command does not exist, please look at the following:"
+              message_help
+              ;;
+          esac
           ;;
         *)
           echo "This command does not exist, please look at the following:"
@@ -73,7 +139,7 @@ function message {
 
 function message_help {
   echo
-  echo "Usage: $BASENAME message <chats> <apikey <key> | sendto <group> <message> | receivefrom <group>>"
+  echo "Usage: $BASENAME message <chats> <apikey <key> | sendto <group> <message> | receivefrom read|mark-read <group>>"
   echo
   echo "You can get your token from https://developer.gitter.im/docs/welcome by signing in, it should show up immediately or by navigating to https://developer.gitter.im/apps"
   echo
@@ -89,7 +155,10 @@ function message_help {
   echo "  $BASENAME message gitter sendto treehouses/Lobby \"Hi, you are very awesome\""
   echo "     Sends a message to a gitter channel"
   echo
-  echo "  $BASENAME message gitter receivefrom treehouses/Lobby" 
-  echo "     Receives unread messages from a gitter channel"
+  echo "  $BASENAME message gitter receivefrom read treehouses/Lobby" 
+  echo "     Receives and displays unread messages from a gitter channel"
+  echo
+  echo "  $BASENAME message gitter receivefrom mark-read treehouses/Lobby" 
+  echo "     Marks unread messages from a gitter channel to read"
   echo
 }


### PR DESCRIPTION
fixes #1700

How to test:

From the cli directory, checkout the branch message-gitter-receivefrom-mark-read. To set up an apikey for gitter, follow these instructions:
```
git checkout message-gitter-receivefrom-mark-read
./cli.sh message gitter apikey
```
follow the instructions that show up
then:
choose a Gitter channel where you have unread messages, it could also be with a user.
`./cli.sh message gitter receivefrom mark-read <channel/user>`
You should have unread messages displayed and you can check if they are read by running the above command again, where you should see nothing but: 
`You have no unread messages at the moment`


