### PR TITLE
`treehouses clone` progress (fixes #1705)

### DIFF
--- a/modules/clone.sh
+++ b/modules/clone.sh
@@ -27,7 +27,7 @@ function clone {
   if [ $a -eq $b ] || [ $a -lt $b ]; then
     echo "copying...."
     echo u > /proc/sysrq-trigger
-    dd if=/dev/mmcblk0 bs=1M of="$device"
+    dd if=/dev/mmcblk0 bs=1M of="$device" status=progress
   fi
 
   echo ; echo "A reboot is needed to re-enable write permissions to OS."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.23.51",
+  "version": "1.23.55",
   "remote": "2500",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
show progress when running `treehouses clone` using inbuilt `dd status`
more detailed progress bar can be made by intercepting `dd` pipe with `pv`

https://askubuntu.com/questions/215505/how-do-you-monitor-the-progress-of-dd

- fixes #1705