### PR TITLE
`treehouses sshkey delete` refactor (fixes #1712)

### DIFF
--- a/modules/sshkey.sh
+++ b/modules/sshkey.sh
@@ -39,7 +39,7 @@ function sshkey () {
       echo "Usage: $BASENAME sshkey delete \"<key>\""
       exit 1
     fi
-    keys="$(echo $@ | sed 's/delete //')"
+    keys="$(echo "$@" | sed 's/delete //')"
     if grep -Fxq "$keys" /root/.ssh/authorized_keys; then
       sed -i "\:$keys:d" /root/.ssh/authorized_keys
       echo "Key deleted from root keys."

--- a/modules/sshkey.sh
+++ b/modules/sshkey.sh
@@ -47,8 +47,8 @@ function sshkey () {
       echo "Key not found in root keys."
     fi
     if [ "$(detectrpi)" != "nonrpi" ]; then
-      if grep -Fxq "$2" /home/pi/.ssh/authorized_keys; then
-        sed -i "\:$2:d" /home/pi/.ssh/authorized_keys
+      if grep -Fxq "$keys" /home/pi/.ssh/authorized_keys; then
+        sed -i "\:$keys:d" /home/pi/.ssh/authorized_keys
         echo "Key deleted from pi keys."
       else
         echo "Key not found in pi keys."

--- a/modules/sshkey.sh
+++ b/modules/sshkey.sh
@@ -39,13 +39,9 @@ function sshkey () {
       echo "Usage: $BASENAME sshkey delete \"<key>\""
       exit 1
     fi
-    if [ "$2" == "ssh-rsa" ]; then
-      echo "Error: missing qoutes"
-      echo "Usage: $BASENAME sshkey delete \"<key>\""
-      exit 1
-    fi
-    if grep -Fxq "$2" /root/.ssh/authorized_keys; then
-      sed -i "\:$2:d" /root/.ssh/authorized_keys
+    keys="$(echo $@ | sed 's/delete //')"
+    if grep -Fxq "$keys" /root/.ssh/authorized_keys; then
+      sed -i "\:$keys:d" /root/.ssh/authorized_keys
       echo "Key deleted from root keys."
     else
       echo "Key not found in root keys."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.23.55",
+  "version": "1.23.60",
   "remote": "3000",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
fixes #1712 
ability to delete keys without inputting quotes
```
treehouses sshkey delete ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINPobRqfqhCx7x0ydvuOq3gUfkOTIF7O4wiBBSk0uzg9 root@treehouses
Key deleted from root keys.
Key not found in pi keys.
```