### PR TITLE
`treehouses services novnc` (fixes #1779)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ services                                  executes the given command on the spec
    [pylon]                                Pylon is a web based integrated development environment built with Node.js as a backend
    [rutorrent]                            Rutorrent is a popular rtorrent client with a webui for ease of use
    [webssh]                               Webssh is a simple web application to be used as an ssh client to connect to your ssh servers
+   [novnc]                                noVNC is an open source VNC client and runs well in any modern browsers
 tor [list|ports|add|delete|deleteall]     deals with services on tor hidden network
     [start|stop|destroy|notice]
     [status|refresh]

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -96,6 +96,7 @@ services                                  executes the given command on the spec
    [pylon]                                Pylon is a web based integrated development environment built with Node.js as a backend
    [rutorrent]                            Rutorrent is a popular rtorrent client with a webui for ease of use
    [webssh]                               Webssh is a simple web application to be used as an ssh client to connect to your ssh servers
+   [novnc]                                noVNC is an open source VNC client and runs well in any modern browsers
 tor [list|ports|add|delete|deleteall]     deals with services on tor hidden network
     [start|stop|destroy|notice]
     [status|refresh]

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -661,6 +661,7 @@ function services_help {
   echo "  pylon           Pylon is a web based integrated development environment built with Node.js as a backend"
   echo "  rutorrent       Rutorrent is a popular rtorrent client with a webui for ease of use"
   echo "  webssh          Webssh is a simple web application to be used as an ssh client to connect to your ssh servers"
+  echo "  novnc           noVNC is an open source VNC client and runs well in any modern browsers"
   echo
   echo
   echo "Top-Level Commands:"

--- a/modules/vnc.sh
+++ b/modules/vnc.sh
@@ -74,6 +74,7 @@ case "$option" in
       echo "Please reboot your system."
     fi
     ;;
+  # NEED TO ADD
  *)
     echo "Error: only 'on', 'off', 'info' options are supported";
     exit 1;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "grocy", "kolibri", "mongodb", "moodle", "netdata", "nextcloud", "ntopng", "planet",
     "invoiceninja", "librespeed", "portainer", "privatebin", "mastodon", "couchdb",
     "mariadb", "seafile", "minetest", "dokuwiki", "transmission", "cloud9", "bookstack",
-    "piwigo", "jellyfin", "pylon", "rutorrent", "webssh"
+    "piwigo", "jellyfin", "pylon", "rutorrent", "webssh", "novnc"
   ],
   "author": {
     "name": "OLE treehouses team",

--- a/services/install-novnc.sh
+++ b/services/install-novnc.sh
@@ -10,10 +10,6 @@ version: '3'
 services:
   novnc:
     image: treehouses/novnc
-    environment:
-      - NOVNC_PORT=6080
-      - NOVNC_HOME=/srv/novnc
-      - GET_HOST="ip route | awk '/default/ { print \$3 }'"
     ports:
     - "6080:6080"
 EOF

--- a/services/install-novnc.sh
+++ b/services/install-novnc.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+function install {
+  # create service directory
+  mkdir -p /srv/novnc
+
+  # create yml(s)
+  cat << EOF > /srv/novnc/novnc.yml
+version: '3'
+services:
+  novnc:
+    image: treehouses/novnc
+    environment:
+      - NOVNC_PORT=6080
+      - NOVNC_HOME=/srv/novnc
+      - GET_HOST="ip route | awk '/default/ { print \$3 }'"
+    ports:
+    - "6080:6080"
+EOF
+
+  # create .env with default values
+  # {
+  #  echo "EXAMPLE_VAR="
+  # } > /srv/<service>/.env
+
+  # add autorun
+  cat << EOF > /srv/novnc/autorun
+novnc_autorun=true
+
+if [ "$novnc_autorun" = true ]; then
+  treehouses services novnc up
+fi
+
+
+EOF
+}
+
+# environment var
+function uses_env {
+  echo false
+}
+
+# add supported arch(es)
+function supported_arches {
+  echo "armv7l"
+  echo "armv6l"
+  echo "x86_64"
+}
+
+# add port(s)
+function get_ports {
+  echo "6080"
+}
+
+# add size (in MB)
+function get_size {
+  echo "133"
+}
+
+# add info
+function get_info {
+  echo "https://github.com/treehouses/novnc"
+  echo
+  echo "\"noVNC is both a HTML VNC client JavaScript library and an application built on top of that library. noVNC runs well in any modern browser including mobile browsers (iOS and Android).\""
+}
+
+# add svg icon
+function get_icon {
+  cat <<EOF
+<svg icon code>
+EOF
+}

--- a/services/install-novnc.sh
+++ b/services/install-novnc.sh
@@ -41,7 +41,7 @@ function uses_env {
 }
 
 # add supported arch(es)
-function supported_arches {
+function supported_arms {
   echo "armv7l"
   echo "armv6l"
   echo "x86_64"

--- a/tests/services/novnc.bats
+++ b/tests/services/novnc.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+load ../test-helper
+
+@test "$clinom services novnc info" {
+  run "${clicmd}" services novnc info
+  assert_success && assert_output -p 'https://github.com/treehouses/novnc'
+}
+
+@test "$clinom services novnc install" {
+  run "${clicmd}" services novnc install
+  assert_success && assert_output -p 'installed'
+}
+
+@test "$clinom services novnc up" {
+  run "${clicmd}" services novnc up
+  sleep 5
+  assert_success && assert_output -p 'novnc built and started'
+}
+
+@test "$clinom services novnc restart" {
+  run "${clicmd}" services novnc restart
+  sleep 5
+  assert_success && assert_output -p 'novnc built and started'
+}
+
+@test "$clinom services available" {
+  run "${clicmd}" services available
+  assert_success && assert_output -p 'novnc'
+}
+
+@test "$clinom services running" {
+  run "${clicmd}" services running
+  assert_success && assert_output -p 'novnc'
+}
+
+@test "$clinom services running full" {
+  run "${clicmd}" services running full
+  assert_success && assert_output -p 'treehouses/novnc'
+}
+
+@test "$clinom services installed" {
+  run "${clicmd}" services installed
+  assert_success && assert_output -p 'novnc'
+}
+
+@test "$clinom services installed full" {
+  run "${clicmd}" services installed full
+  assert_success && assert_output -p 'treehouses/novnc'
+}
+
+@test "$clinom services ports" {
+  run "${clicmd}" services ports
+  assert_success && assert_output -p 'port 6080'
+}
+
+@test "$clinom services novnc port" {
+  run "${clicmd}" services novnc port
+  assert_success && assert_output -p '6080'
+}
+
+@test "$clinom services novnc ps" {
+  run "${clicmd}" services novnc ps
+  assert_success && assert_output -p 'treehouses/novnc'
+}
+
+@test "$clinom services novnc url" {
+  run "${clicmd}" services novnc url
+  assert_output -p '6080'
+}
+
+@test "$clinom services novnc autorun" {
+  run "${clicmd}" services novnc autorun
+  assert_success
+}
+
+@test "$clinom services novnc autorun true" {
+  run "${clicmd}" services novnc autorun true
+  assert_success && assert_output -p 'set to true'
+}
+
+@test "$clinom services novnc stop" {
+  run "${clicmd}" services novnc stop
+  assert_success && assert_output -p 'novnc stopped'
+}
+
+@test "$clinom services novnc start" {
+  run "${clicmd}" services novnc start
+  assert_success && assert_output -p 'novnc started'
+}
+
+@test "$clinom services novnc down" {
+  run "${clicmd}" services novnc down
+  assert_success && assert_output -p 'novnc stopped and removed'
+}
+
+@test "$clinom services novnc icon" {
+  run "${clicmd}" services novnc icon
+  assert_success && assert_output -p 'svg'
+}
+
+@test "$clinom services novnc cleanup" {
+  run "${clicmd}" services novnc cleanup
+  assert_success && assert_output -p 'cleaned up'
+}


### PR DESCRIPTION
### To do:
- [x] main functions
- [ ] add icon
- [ ] add create vnc password in ``treehouses vnc``
- [ ] add change authentication in ``treehouses vnc``

### Set up:
In order to test **novnc**, we have to change the VNC authentication to ``VNC password``, by default is ``UNIX password``.

There are two ways to do it:

*First way:*

**NOTE: reboot if necessary, there is a bug in ``treehouses vnc off`` #1780, run following commands exact once**
1. if vnc already on, turn off the vnc ``treehouses vnc off``; else go to 2
2. set up a password for vnc service mode ``vncpasswd -service``
3. add the config by the following command
```bash
echo "Authentication=VncAuth" >> /root/.vnc/config.d/vncserver-x11
```
4. turn on the vnc ``treehouses vnc on``

*Second way:*
1. turn on the vnc ``treehouses vnc on``
2. access vnc via a [realvnc viewer](https://www.realvnc.com/en/connect/download/viewer/)
3. click the icon on right top
![image](https://user-images.githubusercontent.com/17788840/90084008-ffb76380-dcc8-11ea-9276-be617d29178a.png)
open the option tab
![image](https://user-images.githubusercontent.com/17788840/90084067-2f666b80-dcc9-11ea-9e7f-a539b9847d97.png)
change the authentication to VNC password and create a password
![image](https://user-images.githubusercontent.com/17788840/90084983-aef53a00-dccb-11ea-86ec-61ddc4aa1dfa.png)

### How to test:
- ``./cli.sh services novnc install``
- ``./cli.sh services novnc up``
- open a broswer and go to: ``<ip address>:6080/vnc.html?host=<ip address>&port=6080``

