### PR TITLE
`treehouses tg-terminal` (fixes #1778)

### DIFF
--- a/modules/tg-terminal.sh
+++ b/modules/tg-terminal.sh
@@ -5,7 +5,12 @@ function tg-terminal {
     systemctl is-active tg-terminal.service
     ;;
   "install")
-    tg-terminal-install "$2"
+    if [ -z "$2"]; then
+      echo "Please pass the token as the argument"
+      exit 1
+    else
+      tg-terminal-install "$2"
+    fi
     ;;
   "start")
     systemctl start tg-terminal.service
@@ -14,6 +19,7 @@ function tg-terminal {
   "enable")
     systemctl enable tg-terminal.service --quiet
     echo "Bot enabled."
+    ;;
   *)
     echo "No option as $1."
     exit 1
@@ -22,7 +28,6 @@ function tg-terminal {
 }
 
 function tg-terminal-install {
-  checkargn $# 1
   echo "Installing.."
   rm -rf /srv/tg-terminal/
 	mkdir -p /srv/tg-terminal/shareFolder/
@@ -33,7 +38,7 @@ function tg-terminal-install {
 	wget -q -P /srv/tg-terminal/ https://raw.githubusercontent.com/darthnoward/remoteTelegramShell/master/config.txt || exit 1
   rm -f /etc/systemd/system/tg-terminal.service
   wget -q -P /etc/systemd/system/ https://raw.githubusercontent.com/darthnoward/remoteTelegramShell/master/tg-terminal.service || exit 1
-	sed -i 's/token =/token = $1/g' /srv/tg-terminal/config.txt
+	sed -i "s/token =/token = $1/g" /srv/tg-terminal/config.txt
 	pip3 install -q pyTelegramBotApi || exit 1
   echo "tg-terminal install."	
 }

--- a/modules/tg-terminal.sh
+++ b/modules/tg-terminal.sh
@@ -1,12 +1,19 @@
 function tg-terminal {
   checkroot
   case $1 in
+  "")
+    systemctl is-active tg-terminal.service
+    ;;
   "install")
-    tg-terminal-install
+    tg-terminal-install "$2"
     ;;
   "start")
-    python3 /srv/tg-terminal/telegramShellBot.py & disown
+    systemctl start tg-terminal.service
+    echo "Bot started."
     ;;
+  "enable")
+    systemctl enable tg-terminal.service --quiet
+    echo "Bot enabled."
   *)
     echo "No option as $1."
     exit 1
@@ -15,13 +22,18 @@ function tg-terminal {
 }
 
 function tg-terminal-install {
+  checkargn $# 1
+  echo "Installing.."
+  rm -rf /srv/tg-terminal/
 	mkdir -p /srv/tg-terminal/shareFolder/
 	touch /srv/tg-terminal/users.txt
 	touch /srv/tg-terminal/log.txt
 	
 	wget -q -P /srv/tg-terminal/ https://raw.githubusercontent.com/darthnoward/remoteTelegramShell/master/telegramShellBot.py || exit 1
 	wget -q -P /srv/tg-terminal/ https://raw.githubusercontent.com/darthnoward/remoteTelegramShell/master/config.txt || exit 1
-	sed -i 's/token =/token = 1304518352:AAHYhhLGLZvTzXsYmt-A5oeEL6oUqCUvP6E/g' /srv/tg-terminal/config.txt
+  rm -f /etc/systemd/system/tg-terminal.service
+  wget -q -P /etc/systemd/system/ https://raw.githubusercontent.com/darthnoward/remoteTelegramShell/master/tg-terminal.service || exit 1
+	sed -i 's/token =/token = $1/g' /srv/tg-terminal/config.txt
 	pip3 install -q pyTelegramBotApi || exit 1
   echo "tg-terminal install."	
 }

--- a/modules/tg-terminal.sh
+++ b/modules/tg-terminal.sh
@@ -5,7 +5,7 @@ function tg-terminal {
     systemctl is-active tg-terminal.service
     ;;
   "install")
-    if [ -z "$2"]; then
+    if [ -z "$2" ]; then
       echo "Please pass the token as the argument."
       exit 1
     else
@@ -26,7 +26,7 @@ function tg-terminal {
     ;;
   "stop")
     systemctl stop tg-terminal.service
-    echo "bot stopped."
+    echo "Bot stopped."
     ;;
   "enable")
     systemctl enable tg-terminal.service --quiet

--- a/modules/tg-terminal.sh
+++ b/modules/tg-terminal.sh
@@ -20,12 +20,12 @@ function tg-terminal {
     echo "tg-terminal uninstalled."
     ;;
   "start")
-    systemctl start tg-terminal.service
+    systemctl start tg-terminal.service --quiet
     echo "Bot started."
     echo "Text your bot on Telegram \"/start\" to get started"
     ;;
   "stop")
-    systemctl stop tg-terminal.service
+    systemctl stop tg-terminal.service --quiet
     echo "Bot stopped."
     ;;
   "enable")
@@ -46,7 +46,7 @@ function tg-terminal {
 
 function tg-terminal-install {
   echo "Installing.."
-  tg-terminal uninstall
+  tg-terminal uninstall > /dev/null
 	mkdir -p /srv/tg-terminal/shareFolder/
 	touch /srv/tg-terminal/users.txt
 	touch /srv/tg-terminal/log.txt
@@ -56,7 +56,7 @@ function tg-terminal-install {
   wget -q -P /etc/systemd/system/ https://raw.githubusercontent.com/darthnoward/remoteTelegramShell/master/tg-terminal.service || exit 1
 	sed -i "s/token =/token = $1/g" /srv/tg-terminal/config.txt
 	pip3 install -q pyTelegramBotApi || exit 1
-  echo "tg-terminal install."	
+  echo "tg-terminal installed."	
 }
 
 function tg-terminal_help {

--- a/modules/tg-terminal.sh
+++ b/modules/tg-terminal.sh
@@ -22,7 +22,7 @@ function tg-terminal {
   "start")
     systemctl start tg-terminal.service --quiet
     echo "Bot started."
-    echo "Text your bot on Telegram \"/start\" to get started"
+    echo "Text your bot on Telegram \"/start\" to get started."
     ;;
   "stop")
     systemctl stop tg-terminal.service --quiet
@@ -46,7 +46,7 @@ function tg-terminal {
 
 function tg-terminal-install {
   echo "Installing.."
-  tg-terminal uninstall > /dev/null
+  tg-terminal uninstall > /dev/null 2>&1
 	mkdir -p /srv/tg-terminal/shareFolder/
 	touch /srv/tg-terminal/users.txt
 	touch /srv/tg-terminal/log.txt

--- a/modules/tg-terminal.sh
+++ b/modules/tg-terminal.sh
@@ -1,0 +1,31 @@
+function tg-terminal {
+  checkroot
+  case $1 in
+  "install")
+    tg-terminal-install
+    ;;
+  "start")
+    python3 /srv/tg-terminal/telegramShellBot.py & disown
+    ;;
+  *)
+    echo "No option as $1."
+    exit 1
+    ;;
+  esac
+}
+
+function tg-terminal-install {
+	mkdir -p /srv/tg-terminal/shareFolder/
+	touch /srv/tg-terminal/users.txt
+	touch /srv/tg-terminal/log.txt
+	
+	wget -q -P /srv/tg-terminal/ https://raw.githubusercontent.com/darthnoward/remoteTelegramShell/master/telegramShellBot.py || exit 1
+	wget -q -P /srv/tg-terminal/ https://raw.githubusercontent.com/darthnoward/remoteTelegramShell/master/config.txt || exit 1
+	sed -i 's/token =/token = 1304518352:AAHYhhLGLZvTzXsYmt-A5oeEL6oUqCUvP6E/g' /srv/tg-terminal/config.txt
+	pip3 install -q pyTelegramBotApi || exit 1
+  echo "tg-terminal install."	
+}
+
+function tg-terminal_help {
+  echo
+}

--- a/modules/tg-terminal.sh
+++ b/modules/tg-terminal.sh
@@ -1,27 +1,44 @@
 function tg-terminal {
   checkroot
   case $1 in
-  "")
+  "" | "status")
     systemctl is-active tg-terminal.service
     ;;
   "install")
     if [ -z "$2"]; then
-      echo "Please pass the token as the argument"
+      echo "Please pass the token as the argument."
       exit 1
     else
       tg-terminal-install "$2"
     fi
     ;;
+  "uninstall")
+    tg-terminal stop
+    tg-terminal disable
+    rm -rf /srv/tg-terminal/
+    rm -f /etc/systemd/system/tg-terminal.service
+    echo "tg-terminal uninstalled."
+    ;;
   "start")
     systemctl start tg-terminal.service
     echo "Bot started."
+    echo "Text your bot on Telegram \"/start\" to get started"
+    ;;
+  "stop")
+    systemctl stop tg-terminal.service
+    echo "bot stopped."
     ;;
   "enable")
     systemctl enable tg-terminal.service --quiet
     echo "Bot enabled."
     ;;
+  "disable")
+    systemctl disable tg-terminal.service --quiet
+    echo "Bot disabled."
+    ;;
   *)
     echo "No option as $1."
+    tg-terminal_help
     exit 1
     ;;
   esac
@@ -29,14 +46,13 @@ function tg-terminal {
 
 function tg-terminal-install {
   echo "Installing.."
-  rm -rf /srv/tg-terminal/
+  tg-terminal uninstall
 	mkdir -p /srv/tg-terminal/shareFolder/
 	touch /srv/tg-terminal/users.txt
 	touch /srv/tg-terminal/log.txt
 	
 	wget -q -P /srv/tg-terminal/ https://raw.githubusercontent.com/darthnoward/remoteTelegramShell/master/telegramShellBot.py || exit 1
 	wget -q -P /srv/tg-terminal/ https://raw.githubusercontent.com/darthnoward/remoteTelegramShell/master/config.txt || exit 1
-  rm -f /etc/systemd/system/tg-terminal.service
   wget -q -P /etc/systemd/system/ https://raw.githubusercontent.com/darthnoward/remoteTelegramShell/master/tg-terminal.service || exit 1
 	sed -i "s/token =/token = $1/g" /srv/tg-terminal/config.txt
 	pip3 install -q pyTelegramBotApi || exit 1
@@ -44,5 +60,16 @@ function tg-terminal-install {
 }
 
 function tg-terminal_help {
+  echo
+  echo  "A bot service for terminal over Telegram."
+  echo
+  echo  "Usage:  $BASENAME tg-terminal <install|uninstall|enable|disable|start|stop> [token]"
+  echo
+  echo  "        $BASENAME tg-terminal install <token>"
+  echo  "                Install tg-terminal with token given"
+  echo  "                To generate a token, see https://core.telegram.org/bots#6-botfather"
+  echo
+  echo  "        $BASENAME tg-terminal [enable|disable|start|stop]"
+  echo  "                enable/disable/start/stop the bot for terminal over Telegram"
   echo
 }


### PR DESCRIPTION
fixes #1778 

# what does it do?

serves as a terminal over on Telegram
send commands to a Telegram bot and get the output.

![Screenshot 08-20 at 12 32](https://user-images.githubusercontent.com/51189233/90717080-3ef53e00-e2e1-11ea-9d12-47a052684847.jpg)

easy to access your rpi even if you're on a phone!

# how to test it?

- apply for a Telegram account if you don't have one and install Telegram client for mobile/desktop
- create a Telegram bot and get the **token** for it, see [this link](https://core.telegram.org/bots#6-botfather) for help, the format of the token would be similar to `110201543:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw`
- run `treehouses upgrade cli tg-terminal` to switch to this branch
- run `treehouses tg-terminal install [put the token here]` to install
- run `treehouses tg-terminal start` to start it
- Text your Bot on Telegram "/start", then enter the password `treehouses` when prompted
- Text your Bot on Telegram "/run"

Terminal over on Telegram is now working!!
