### PR TITLE
`treehouses localtunnel <port>` fixes #1802

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ remote <check|status|upgrade|services>    helps with treehouses remote android a
        <statuspage|help|key>
 log <0|1|2|3|4|show|max>                  gets/sets log level and shows log
 blocker <0|1|2|3|4||max>                  website blocking levels using /etc/hosts
+localtunnel <port>												tunnels local port to the internet	
 sdbench                                   displays read and write speed of micro SD card
 inspire [fact|joke|qotd|random]           displays quote based on user input
 convert <input file> <output file>        converts video and audio files

--- a/_treehouses
+++ b/_treehouses
@@ -204,6 +204,7 @@ treehouses led easter
 treehouses led lantern
 treehouses led random
 treehouses locale
+treehouses localtunnel
 treehouses log
 treehouses log 0
 treehouses log 1

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -123,6 +123,7 @@ remote <check|status|upgrade|services>    helps with treehouses remote android a
        <statuspage|help|key>
 log <0|1|2|3|4|show|max>                  gets/sets log level and shows log
 blocker <0|1|2|3|4||max>                  website blocking levels using /etc/hosts
+localtunnel <port>												tunnel local port to the internet
 sdbench                                   displays read and write speed of micro SD card
 inspire [fact|joke|qotd|random]           displays quote based on user input
 convert <input file> <output file>        converts video and audio files

--- a/modules/localtunnel.sh
+++ b/modules/localtunnel.sh
@@ -1,0 +1,28 @@
+function localtunnel {
+  # check if localtunnel exists
+  check_missing_binary lt
+
+  case "$1" in
+    "")
+      picture_help
+    ;;
+    
+    *)
+      lt -h "https://serverless.social" -p "$1"
+    ;;
+  esac
+}
+
+function localtunnel_help {
+  echo
+  echo "Usage: $BASENAME localtunnel [port number] "
+  echo
+  echo "  exposes a local port to outside world"
+  echo
+  echo "Example:"
+	echo
+  echo "  \`$BASENAME localtunnel 3000\`"
+	echo 
+  echo "  your url is: https://pink-catfish-46.serverless.social "
+  echo
+}


### PR DESCRIPTION
fixes #1802
## Quick Start

```bash
# install localtunnel
npm i localtunnel

# Expose port 80 (planet learning on rpi) to the internet
cli.sh localtunnel 80
```
copy and paste url to browser 





![WindowsTerminal_iJrB2gL2rk](https://user-images.githubusercontent.com/4152386/91410951-41740c80-e87a-11ea-8981-0c2e1c08da59.png)
![firefox_pN0RXDMklV](https://user-images.githubusercontent.com/4152386/91411134-7f713080-e87a-11ea-8fbb-8ab1905b3b92.png)
