### PR TITLE
`treehouses ssh 2fa add/remove/show` of not existing user should give error (fixes #1828)

### DIFF
--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -39,7 +39,7 @@ function ssh {
           elif [ "$3" == "root" ]; then
             echo "You can't add or remove 2FA for root user."
             echo "You should only login as root user via a ssh key."
-          elif cat /etc/passwd | grep "/home" | cut -d: -f1; then
+          elif cat "/etc/passwd" | grep "/home" | cut -d: -f1; then
             if [ "$2" == "add" ]; then
               if [ -f /home/$3/.google_authenticator ]; then
                 echo "2FA for $3 already exists."

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -39,7 +39,7 @@ function ssh {
           elif [ "$3" == "root" ]; then
             echo "You can't add or remove 2FA for root user."
             echo "You should only login as root user via a ssh key."
-          elif cat /etc/passwd | grep -q "$3" | cut -d: -f1; then
+          elif cat /etc/passwd | grep -q "/home" | cut -d: -f1; then
             if [ "$2" == "add" ]; then
               if [ -f /home/$3/.google_authenticator ]; then
                 echo "2FA for $3 already exists."

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -39,7 +39,7 @@ function ssh {
           elif [ "$3" == "root" ]; then
             echo "You can't add or remove 2FA for root user."
             echo "You should only login as root user via a ssh key."
-          elif cat /etc/passwd | grep "/home" | cut -d: -f1; then
+          elif cat /etc/passwd | grep -q "$3" | cut -d: -f1; then
             if [ "$2" == "add" ]; then
               if [ -f /home/$3/.google_authenticator ]; then
                 echo "2FA for $3 already exists."

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -39,7 +39,7 @@ function ssh {
           elif [ "$3" == "root" ]; then
             echo "You can't add or remove 2FA for root user."
             echo "You should only login as root user via a ssh key."
-          elif cat /etc/passwd | grep -q "$3" | cut -d: -f1; then
+          elif cat /etc/passwd | grep "/home" | cut -d: -f1; then
             if [ "$2" == "add" ]; then
               if [ -f /home/$3/.google_authenticator ]; then
                 echo "2FA for $3 already exists."

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -39,7 +39,7 @@ function ssh {
           elif [ "$3" == "root" ]; then
             echo "You can't add or remove 2FA for root user."
             echo "You should only login as root user via a ssh key."
-          elif cat "/etc/passwd" | grep "/home" | cut -d: -f1; then
+          elif cat /etc/passwd | grep "/home" | cut -d: -f1; then
             if [ "$2" == "add" ]; then
               if [ -f /home/$3/.google_authenticator ]; then
                 echo "2FA for $3 already exists."

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -39,7 +39,7 @@ function ssh {
           elif [ "$3" == "root" ]; then
             echo "You can't add or remove 2FA for root user."
             echo "You should only login as root user via a ssh key."
-          elif cat /etc/passwd | grep -q "/home" | cut -d: -f1; then
+          elif cat /etc/passwd | grep "/home" | cut -d: -f1; then
             if [ "$2" == "add" ]; then
               if [ -f /home/$3/.google_authenticator ]; then
                 echo "2FA for $3 already exists."

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -133,7 +133,7 @@ function ssh {
 
 function ssh_help {
   echo
-  echo "Usage: $BASENAME ssh [on|off|fingerprint]"
+  echo "Usage: $BASENAME ssh [on|off|fingerprint|2fa]"
   echo
   echo "Enables or disables the SSH service"
   echo

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -39,7 +39,7 @@ function ssh {
           elif [ "$3" == "root" ]; then
             echo "You can't add or remove 2FA for root user."
             echo "You should only login as root user via a ssh key."
-          elif cat /etc/passwd | grep "/bin/bash" | grep -q "$3" | cut -d: -f1; then
+          elif cat /etc/passwd | grep -q "$3" | cut -d: -f1; then
             if [ "$2" == "add" ]; then
               if [ -f /home/$3/.google_authenticator ]; then
                 echo "2FA for $3 already exists."


### PR DESCRIPTION
This fixes issue #1828 