### PR TITLE
Add function for warning "⚠️" in globals and update of `treehouses password`  (fixes #1846)

### DIFF
--- a/modules/globals.sh
+++ b/modules/globals.sh
@@ -84,6 +84,12 @@ function checkwifi {
   fi
 }
 
+function warningsign {
+  if ! [[ $(pstree -ps $$) == *"python"* ]]; then
+      echo -ne "\e[0;33m\U26A0 \e[0m"
+  fi
+}
+
 function restart_hotspot {
   restart_service dhcpcd || true
   ifdown wlan0 || true

--- a/modules/password.sh
+++ b/modules/password.sh
@@ -3,6 +3,7 @@ function password {
   checkroot
   checkargn $# 1
   if [[ $1 == "" ]]; then
+    warningsign
     log_and_exit1 "Error: Password not entered"
   elif [ $1 == "disable" ]; then
     disablepassword 


### PR DESCRIPTION
This fixes issue #1846 