### PR TITLE
`treehouses sshtunnel` call function for warning "⚠️" (fixes #1846)

### DIFF
--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -4,6 +4,7 @@ function sshtunnel {
   checkroot
 
   if { [ ! -f "/etc/tunnel" ] || [ ! -f "/etc/cron.d/autossh" ]; } && [[ ! "$*" =~ "add host" ]] && [[ ! "$*" =~ "remove all" ]] && [[ ! "$*" =~ "check" ]] && [[ ! "$*" =~ "key" ]]; then
+    warningsign
     echo "Error: no tunnel has been set up"
     echo "Run '$BASENAME sshtunnel add host <port interval> [host]' to add a key for the tunnel"
     exit 1
@@ -20,6 +21,7 @@ function sshtunnel {
           host=$4
 
           if [ -z "$portinterval" ] || [[ ! $portinterval =~ $re ]]; then
+            warningsign
             echo "Error: a numeric port interval is required"
             echo "Usage: $BASENAME sshtunnel add host <port interval> [host]"
             exit 1
@@ -29,6 +31,7 @@ function sshtunnel {
           if [ -z "$host" ]; then
             host="ole@pirate.ole.org"
           elif ! echo $host | grep -q "[]@[]"; then
+            warningsign
             echo "Error: invalid host"
             echo "user@host"
             exit 1
@@ -37,6 +40,7 @@ function sshtunnel {
 
           # check if host already exists
           if grep -qs "$host" /etc/tunnel; then
+            warningsign
             echo "Error: host already exists"
             echo "Try adding individual ports to the host or adding a different host"
             exit 1
@@ -105,14 +109,17 @@ function sshtunnel {
               host=$6
 
               if [ -z "$actual" ] || [[ ! $actual =~ $re ]]; then
+                warningsign
                 echo "Error: a numeric port is required"
                 echo "Usage: $BASENAME sshtunnel add port offset <actual> <offset> [host]"
                 exit 1
               elif [ -z "$offset" ] || [[ ! $offset =~ $re ]]; then
+                warningsign
                 echo "Error: a numeric offset is required"
                 echo "Usage: $BASENAME sshtunnel add port offset <actual> <offset> [host]"
                 exit 1
               elif [ "$offset" -ge 100 ]; then
+                warningsign
                 echo "Error: offset is greater than or equal to 100"
                 echo "Use an offset less than 100 (save some ports for others!)"
                 exit 1
@@ -122,6 +129,7 @@ function sshtunnel {
               if [ -z "$host" ]; then
                 host="ole@pirate.ole.org"
               elif ! echo $host | grep -q "[]@[]"; then
+                warningsign
                 echo "Error: invalid host"
                 echo "user@host"
                 exit 1
@@ -164,6 +172,7 @@ function sshtunnel {
                   done < <(cat /etc/tunnel)
 
                   if [ "$monitoringport" -eq "$((portinterval + offset))" ] || [ "$((monitoringport + 1))" -eq "$((portinterval + offset))" ]; then
+                    warningsign
                     echo "Error: port conflict with monitoring port"
                     echo "Trying to add $((portinterval + offset)) which conflicts with monitoring port $monitoringport"
                     echo "Monitoring ports ${monitoringport::-1} and $((monitoringport + 1)) must be clear"
@@ -187,10 +196,12 @@ function sshtunnel {
               host=$6
 
               if [ -z "$actual" ] || [[ ! $actual =~ $re ]]; then
+                warningsign
                 echo "Error: a numeric port is required"
                 echo "Usage: $BASENAME sshtunnel add port actual <actual> <port> [host]"
                 exit 1
               elif [ -z "$port" ] || [[ ! $port =~ $re ]]; then
+                warningsign
                 echo "Error: a numeric port is required"
                 echo "Usage: $BASENAME sshtunnel add port actual <actual> <port> [host]"
                 exit 1
@@ -200,6 +211,7 @@ function sshtunnel {
               if [ -z "$host" ]; then
                 host="ole@pirate.ole.org"
               elif ! echo $host | grep -q "[]@[]"; then
+                warningsign
                 echo "Error: invalid host"
                 echo "user@host"
                 exit 1
@@ -240,6 +252,7 @@ function sshtunnel {
                   done < <(cat /etc/tunnel)
 
                   if [ "$monitoringport" -eq "$port" ] || [ "$((monitoringport + 1))" -eq "$port" ]; then
+                    warningsign
                     echo "Error: port conflict with monitoring port"
                     echo "Trying to add $port which conflicts with monitoring port $monitoringport"
                     echo "Monitoring ports ${monitoringport::-1} and $((monitoringport + 1)) must be clear"
@@ -259,6 +272,7 @@ function sshtunnel {
               fi
               ;;
             *)
+              warningsign
               echo "Error: unknown command"
               echo "Usage: $BASENAME sshtunnel add port <offset | actual>"
               exit 1
@@ -266,6 +280,7 @@ function sshtunnel {
           esac
           ;;
         *)
+          warningsign
           echo "Error: unknown command"
           echo "Usage: $BASENAME sshtunnel add <host | port>"
           exit 1
@@ -293,6 +308,7 @@ function sshtunnel {
           host=$4
 
           if [ -z "$port" ]; then
+            warningsign
             echo "Error: a port is required"
             echo "Usage: $BASENAME sshtunnel remove port <port> [host]"
             exit 1
@@ -302,6 +318,7 @@ function sshtunnel {
           if [ -z "$host" ]; then
             host="ole@pirate.ole.org"
           elif ! echo $host | grep -q "[]@[]"; then
+            warningsign
             echo "Error: invalid host"
             echo "user@host"
             exit 1
@@ -340,10 +357,12 @@ function sshtunnel {
           host=$3
 
           if [ -z "$host" ]; then
+            warningsign
             echo "Error: a host is required"
             echo "Usage: $BASENAME sshtunnel remove host <host>"
             exit 1
           elif ! echo $host | grep -q "[]@[]"; then
+            warningsign
             echo "Error: invalid host"
             echo "user@host"
             exit 1
@@ -374,6 +393,7 @@ function sshtunnel {
           sshtunnel_kill $host
           ;;
         *)
+          warningsign
           echo "Error: unknown command"
           echo "Usage: $BASENAME sshtunnel remove <all | port | host>"
           exit 1
@@ -404,6 +424,7 @@ function sshtunnel {
 
       if [ ! -z "$host" ]; then
         if ! echo $host | grep -q "[]@[]"; then
+          warningsign
           echo "Error: invalid host"
           echo "user@host"
           exit 1
@@ -540,6 +561,7 @@ function sshtunnel {
               fi
               ;;
             *)
+              warningsign
               echo "Error: unknown command"
               echo "Usage: $BASENAME sshtunnel key send <public | private> [profile]"
               exit 1
@@ -573,6 +595,7 @@ function sshtunnel {
               echo "Saved $3 key to 'id_rsa${profile}${tag}'"
               ;;
             *)
+              warningsign
               echo "Error: unknown command"
               echo "Usage: $BASENAME sshtunnel key receive <public | private> <\$key> [profile]"
               exit 1
@@ -580,6 +603,7 @@ function sshtunnel {
           esac
           ;;
         *)
+          warningsign
           echo "Error: unknown command"
           echo "Usage: $BASENAME sshtunnel key [verify | send | receive]"
           exit 1
@@ -603,6 +627,7 @@ function sshtunnel {
           checkargn $# 3
           value="$3"
           if [ -z "$value" ]; then
+            warningsign
             echo "Error: You must specify a channel URL"
             exit 1
           fi
@@ -614,6 +639,7 @@ function sshtunnel {
           checkargn $# 3
           value="$3"
           if [ -z "$value" ]; then
+            warningsign
             echo "Error: You must specify a channel URL"
             exit 1
           fi
@@ -674,6 +700,7 @@ function sshtunnel {
           fi
           ;;
         *)
+          warningsign
           echo "Error: unknown command"
           echo "Usage: $BASENAME sshtunnel notice [on | add | delete | list | off | now]"
           exit 1
@@ -711,6 +738,7 @@ function sshtunnel {
       echo -e ${message::-3}
       ;;
     *)
+      warningsign
       echo "Error: unknown command"
       echo "Usage: $BASENAME sshtunnel [add|remove|refresh|list|active|check|key|notice|ports]"
       exit 1


### PR DESCRIPTION
This fixes issue #1846 