### PR TITLE
`treehouses led random` 3 lines (fixes #2046)

### DIFF
--- a/modules/led.sh
+++ b/modules/led.sh
@@ -881,7 +881,7 @@ function sandstorm {
 
 function random {
   echo "selecting from: "
-  led_help | grep "\[" | cut -d "[" -f2 | cut -d "]" -f1  | sed -n '1!p'| head -2 | sed 's/|/ /g'| sed -e 's/ random//'
+  led_help | grep "\[" | cut -d "[" -f2 | cut -d "]" -f1  | sed -n '1!p'| head -3 | sed 's/|/ /g'| sed -e 's/ random//'
   rando="$(led_help | grep "\[" \
     | cut -d "[" -f2 \
     | cut -d "]" -f1 \

--- a/modules/led.sh
+++ b/modules/led.sh
@@ -886,7 +886,7 @@ function random {
     | cut -d "[" -f2 \
     | cut -d "]" -f1 \
     | sed -n '1!p' \
-    | head -2 \
+    | head -3 \
     | sed 's/|/\n/g' \
     | sed -e 's/ random//' \
     | shuf -n 1)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.25.9",
+  "version": "1.25.10",
   "remote": "4000",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Fixes `treehouses led random` not having all the led subcommands 