### PR TITLE
`treehouses message` formatting (fixes #2050)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,11 @@ magazines                                 downloads specific magazine issue as a
 resolution <cea|dmt [modes]>              sets the screen resolution
 system [cpu|ram|disk|volt|temperature]    display real system informations
 message                                   sends message to chat service
-   <gitter>  <apitoken|authorize>         sets api/channel info in config file and sends/recieves messages in gitter
-             <send|show|read|mark>
+   <gitter>  <apitoken|authorize>         sets api/channel info in config file 
+             <send|show|read|mark>        sends/recieves messages in gitter
              <channels>
-   <slack>   <apitoken|channels>          sets api/channel info in config file and sends/recieves messages in slack
-             <send|show|read|mark>
+   <slack>   <apitoken|channels>          sets api/channel info in config file 
+             <send|show|read|mark>        sends/recieves messages in slack
    <discord> <apitoken|authorize>         sets api/channel info in config file
 shutdown [now|in|force]                   shutdown the system
 ```

--- a/README.md
+++ b/README.md
@@ -165,12 +165,13 @@ magazines                                 downloads specific magazine issue as a
                       [url]               shows the homepage URL of magazine
 resolution <cea|dmt [modes]>              sets the screen resolution
 system [cpu|ram|disk|volt|temperature]    display real system informations
-message gitter <apitoken|authorize>       sets api/channel info in config file and sends/recieves messages in gitter
-               <send|show|read|mark>
-               <channels>
-        slack <apitoken|channels>         sets api/channel info in config file and sends/recieves messages in slack
-              <send|show|read|mark>
-        discord <apitoken|authorize>      sets api/channel info in config file
+message                                   sends message to chat service
+   <gitter>  <apitoken|authorize>         sets api/channel info in config file and sends/recieves messages in gitter
+             <send|show|read|mark>
+             <channels>
+   <slack>   <apitoken|channels>          sets api/channel info in config file and sends/recieves messages in slack
+             <send|show|read|mark>
+   <discord> <apitoken|authorize>         sets api/channel info in config file
 shutdown [now|in|force]                   shutdown the system
 ```
 

--- a/modules/help.sh
+++ b/modules/help.sh
@@ -141,12 +141,13 @@ magazines                                 downloads specific magazine issue as a
                       [url]               shows the homepage URL of magazine
 resolution <cea|dmt [modes]>              sets the screen resolution
 system [cpu|ram|disk|volt|temperature]    display real system informations
-message gitter <apitoken|authorize>       sets api/channel info in config file and sends/recieves messages in gitter
-               <send|show|read|mark>
-               <channels>
-        slack <apitoken|channels>         sets api/channel info in config file and sends/recieves messages in slack
-              <send|show|read|mark>
-        discord <apitoken|authorize>.......sets api/channel info in config file
+message                                   sends message to chat service
+   <gitter>  <apitoken|authorize>         sets api/channel info in config file 
+             <send|show|read|mark>        sends/recieves messages in gitter
+             <channels>
+   <slack>   <apitoken|channels>          sets api/channel info in config file 
+             <send|show|read|mark>        sends/recieves messages in slack
+   <discord> <apitoken|authorize>         sets api/channel info in config file
 shutdown [now|in|force]                   shutdown the system
 EOF
   echo "$helpdefault"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.25.9",
+  "version": "1.25.24",
   "remote": "4000",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Fixed the `message` command to its correct format.