### PR TITLE
update `tests/changelog.bats` (fixes #2095)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.25.22",
+  "version": "1.25.29",
   "remote": "4000",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",

--- a/tests/changelog.bats
+++ b/tests/changelog.bats
@@ -2,8 +2,13 @@
 load test-helper
 
 @test "$clinom changelog" {
-  cp "/usr/lib/node_modules/@treehouses/cli/CHANGELOG.md" ../.
-  run "${clicmd}" changelog
-  assert_success
-  rm "../CHANGELOG.md"
+  if [ ! -f "../CHANGELOG.md" ]; then
+    cp "/usr/lib/node_modules/@treehouses/cli/CHANGELOG.md" ../.
+    run "${clicmd}" changelog
+    assert_success
+    rm "../CHANGELOG.md"
+  else
+    run "${clicmd}" changelog
+    assert_success
+  fi
 }


### PR DESCRIPTION
Updating `changelog.bats` so it doesn't accidentally remove the changelog from `usr/lib...` 