### PR TITLE
`treehouses sshtunnel key name` (fixes #2273)

### DIFF
--- a/_treehouses
+++ b/_treehouses
@@ -361,6 +361,7 @@ treehouses sshtunnel check
 treehouses sshtunnel key
 treehouses sshtunnel key receive private
 treehouses sshtunnel key receive public
+treehouses sshtunnel key name
 treehouses sshtunnel key send private
 treehouses sshtunnel key send public
 treehouses sshtunnel key verify

--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -457,15 +457,15 @@ function sshtunnel {
     key)
       case "$2" in
         "")
-          if [ ! -f "/root/.ssh/$SSHKeyName" ]; then
+          if [ ! -f "/root/.ssh/$sshkeyname" ]; then
               ssh-keygen -q -N "" > "$LOGFILE" < /dev/zero
           fi
-          cat /root/.ssh/$SSHKeyName.pub
+          cat /root/.ssh/$sshkeyname.pub
           ;;
         verify)
           checkargn $# 2
-          if [ -f "/root/.ssh/$SSHKeyName" ] && [ -f "/root/.ssh/$SSHKeyName.pub" ]; then
-            verify=$(diff <( ssh-keygen -y -e -f "/root/.ssh/$SSHKeyName" ) <( ssh-keygen -y -e -f "/root/.ssh/$SSHKeyName.pub" ))
+          if [ -f "/root/.ssh/$sshkeyname" ] && [ -f "/root/.ssh/$sshkeyname.pub" ]; then
+            verify=$(diff <( ssh-keygen -y -e -f "/root/.ssh/$sshkeyname" ) <( ssh-keygen -y -e -f "/root/.ssh/$sshkeyname.pub" ))
             if [ "$verify" != "" ]; then
               echo -e "Public and private rsa keys ${RED}do not match${NC}"
             else
@@ -491,8 +491,8 @@ function sshtunnel {
                 tag=".pub"
               fi
 
-              if [ -f /root/.ssh/${SSHKeyName}${profile}${tag} ]; then
-                cat /root/.ssh/${SSHKeyName}${profile}${tag}
+              if [ -f /root/.ssh/${sshkeyname}${profile}${tag} ]; then
+                cat /root/.ssh/${sshkeyname}${profile}${tag}
               else
                 log_and_exit1 "No $3 key found"
               fi
@@ -519,10 +519,10 @@ function sshtunnel {
                 tag=".pub"
               fi
 
-              if [ -f /root/.ssh/${SSHKeyName}${profile}${tag} ]; then
+              if [ -f /root/.ssh/${sshkeyname}${profile}${tag} ]; then
                 timestamp=$(date +%Y%m%d%H%M)
-                mv "/root/.ssh/${SSHKeyName}${profile}${tag}" "/root/.ssh/${SSHKeyName}${profile}.${timestamp}${tag}"
-                echo "Created backup of '${SSHKeyName}${profile}${tag}' as '${SSHKeyName}${profile}.${timestamp}${tag}'"
+                mv "/root/.ssh/${sshkeyname}${profile}${tag}" "/root/.ssh/${sshkeyname}${profile}.${timestamp}${tag}"
+                echo "Created backup of '${SSHKeyName}${profile}${tag}' as '${sshkeyname}${profile}.${timestamp}${tag}'"
               fi
 
               echo -e "$key" > "/root/.ssh/${SSHKeyName}${profile}${tag}"
@@ -536,7 +536,7 @@ function sshtunnel {
   	name)
 	  case "$3" in
 	    "")
-	      echo "Current SSH key name: $SSHKeyName"
+	      echo "Current SSH key name: $sshkeyname"
 	      ;;
 	    *)
 	      treehouses config update keyName "$3"

--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -723,10 +723,10 @@ function sshtunnel_help {
   echo "  check                                    runs a checklist of tests"
   echo
   echo "  key                                      shows the public key"
+  echo "      [name] [sshkeyfile]                              sets default SSH key to desired filename"
   echo "      [verify]                                         verifies that the public and private rsa keys match"
   echo "      [send] <public | private> [profile]              sends public / private key"
   echo "      [receive] <public | private> <\$key> [profile]    saves \$key as public / private key"
-  echo "      [name] [SSH key name]                sets default SSH key to desired file"
   echo
   echo "  notice                                   returns whether auto-reporting sshtunnel ports to gitter is on or off"
   echo "      on                                       turns on auto-reporting to gitter"

--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -10,7 +10,7 @@ function sshtunnel {
   re='^[0-9]+$'
   sshkeyname=`treehouses config | grep keyName | sed "s/keyName=//"`
   if [ -z "$sshkeyname" ]; then
-    SSHKeyName="rsa_id"
+    sshkeyname="rsa_id"
   fi
 
   case "$1" in
@@ -522,7 +522,7 @@ function sshtunnel {
               if [ -f /root/.ssh/${sshkeyname}${profile}${tag} ]; then
                 timestamp=$(date +%Y%m%d%H%M)
                 mv "/root/.ssh/${sshkeyname}${profile}${tag}" "/root/.ssh/${sshkeyname}${profile}.${timestamp}${tag}"
-                echo "Created backup of '${SSHKeyName}${profile}${tag}' as '${sshkeyname}${profile}.${timestamp}${tag}'"
+                echo "Created backup of '${sshkeyname}${profile}${tag}' as '${sshkeyname}${profile}.${timestamp}${tag}'"
               fi
 
               echo -e "$key" > "/root/.ssh/${SSHKeyName}${profile}${tag}"

--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -8,7 +8,10 @@ function sshtunnel {
   fi
 
   re='^[0-9]+$'
-  SSHKeyName=`treehouses config | grep keyName | sed "s/${keyName}=//"`
+  SSHKeyName=`treehouses config | grep keyName | sed "s/keyName=//"`
+  if [ -z "$SSHKeyName" ]; then
+    $SSHKeyName='rsa_id'
+  fi
 
   case "$1" in
     add)
@@ -533,8 +536,7 @@ function sshtunnel {
   	name)
 	  case "$3" in
 	    "")
-	      CurrentName=`echo $SSHKeyName | cut -d '=' -f 2`
-	      echo "Current SSH key name: $CurrentName"
+	      echo "Current SSH key name: $SSHKeyName"
 	      ;;
 	    *)
 	      treehouses config update keyName "$3"

--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -8,8 +8,8 @@ function sshtunnel {
   fi
 
   re='^[0-9]+$'
-  SSHKeyName=`treehouses config | grep keyName | sed "s/keyName=//"`
-  if [ -z "$SSHKeyName" ]; then
+  sshkeyname=`treehouses config | grep keyName | sed "s/keyName=//"`
+  if [ -z "$sshkeyname" ]; then
     SSHKeyName="rsa_id"
   fi
 
@@ -50,10 +50,10 @@ function sshtunnel {
           portweb=$((portinterval + 80 - portint_offset))
           portnewcouchdb=$((portinterval + 82 - portint_offset))
 
-          if [ ! -f "/root/.ssh/$SSHKeyName" ]; then
+          if [ ! -f "/root/.ssh/$sshkeyname" ]; then
             ssh-keygen -q -N "" > "$LOGFILE" < /dev/zero
           fi
-          cat /root/.ssh/$SSHKeyName.pub
+          cat /root/.ssh/$sshkeyname.pub
           echo "Port successfully added"
 
           keys=$(ssh-keyscan -H "$hostname" 2>"$LOGFILE")

--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -10,7 +10,7 @@ function sshtunnel {
   re='^[0-9]+$'
   SSHKeyName=`treehouses config | grep keyName | sed "s/keyName=//"`
   if [ -z "$SSHKeyName" ]; then
-    $SSHKeyName="rsa_id"
+    SSHKeyName="rsa_id"
   fi
 
   case "$1" in

--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -525,8 +525,8 @@ function sshtunnel {
                 echo "Created backup of '${sshkeyname}${profile}${tag}' as '${sshkeyname}${profile}.${timestamp}${tag}'"
               fi
 
-              echo -e "$key" > "/root/.ssh/${SSHKeyName}${profile}${tag}"
-              echo "Saved $3 key to '${SSHKeyName}${profile}${tag}'"
+              echo -e "$key" > "/root/.ssh/${sshkeyname}${profile}${tag}"
+              echo "Saved $3 key to '${sshkeyname}${profile}${tag}'"
               ;;
             *)
               log_comment_and_exit1 "Error: unknown command" "Usage: $BASENAME sshtunnel key receive <public | private> <\$key> [profile]"

--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -10,7 +10,7 @@ function sshtunnel {
   re='^[0-9]+$'
   SSHKeyName=`treehouses config | grep keyName | sed "s/keyName=//"`
   if [ -z "$SSHKeyName" ]; then
-    $SSHKeyName='rsa_id'
+    $SSHKeyName="rsa_id"
   fi
 
   case "$1" in
@@ -726,6 +726,7 @@ function sshtunnel_help {
   echo "      [verify]                                         verifies that the public and private rsa keys match"
   echo "      [send] <public | private> [profile]              sends public / private key"
   echo "      [receive] <public | private> <\$key> [profile]    saves \$key as public / private key"
+  echo "      [name] [SSH key name]                sets default SSH key to desired file"
   echo
   echo "  notice                                   returns whether auto-reporting sshtunnel ports to gitter is on or off"
   echo "      on                                       turns on auto-reporting to gitter"

--- a/modules/sshtunnel.sh
+++ b/modules/sshtunnel.sh
@@ -8,7 +8,7 @@ function sshtunnel {
   fi
 
   re='^[0-9]+$'
-  sshkeyname=`treehouses config | grep keyName | sed "s/keyName=//"`
+  sshkeyname=$(treehouses config | grep keyName | sed "s/keyName=//")
   if [ -z "$sshkeyname" ]; then
     sshkeyname="rsa_id"
   fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.26.6",
+  "version": "1.26.7",
   "remote": "4000",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
Added the option `name`:

Example: treehouses sshtunnel key name [SSH key name]

Only `name` without any values will list the current SSH key name.

Adding a value after will name the SSH key to the value.