### PR TITLE
`treehouses services` also ready for `docker compose` (fixes #2294)

### DIFF
--- a/modules/services.sh
+++ b/modules/services.sh
@@ -4,7 +4,7 @@ function services {
   if which docker-compose; then
     dockercompose="docker-compose"
   elif docker compose | grep -q "Usage"; then
-    dokcercompose="docker compose"
+    dockercompose="docker compose"
   else
     echo "Neither docker-compose nor docker compose found."
     echo "Installation instructions can be found at https://github.com/docker/compose"

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -6,8 +6,8 @@ function services {
   elif docker compose | grep -q "Usage"; then
     dockercompose="docker compose"
   else
-    echo "Neither docker-compose nor docker compose found."
-    echo "Installation instructions can be found at https://github.com/docker/compose"
+    echo "neither docker-compose nor docker compose found."
+    echo "installation instructions can be found at https://github.com/docker/compose"
     exit 1
   fi
 

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -1,5 +1,5 @@
 function services {
-  # check_missing_binary docker-compose "docker-compose is missing\ninstall instructions can be found in\nhttps://github.com/docker/compose"
+  check_missing_binary docker "docker is missing\ninstallation instructions can be found at\nhttps://docs.docker.com/engine/install/"
 
   if which docker-compose; then
     dockercompose="docker-compose"

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -1,7 +1,7 @@
 function services {
   check_missing_binary docker "docker is missing\ninstallation instructions can be found at\nhttps://docs.docker.com/engine/install/"
 
-  if which docker-compose; then
+  if which docker-compose > /dev/null 2>&1; then
     dockercompose="docker-compose"
   elif docker compose | grep -q "Usage"; then
     dockercompose="docker compose"

--- a/modules/services.sh
+++ b/modules/services.sh
@@ -1,10 +1,10 @@
 function services {
   # check_missing_binary docker-compose "docker-compose is missing\ninstall instructions can be found in\nhttps://github.com/docker/compose"
 
-  if docker-compose version 2>/dev/null | grep -q "Docker Compose version"; then
-    dockercompose="docker compose"
-  elif docker-compose version 2>/dev/null | grep -q "docker-compose version"; then
+  if which docker-compose; then
     dockercompose="docker-compose"
+  elif docker compose | grep -q "Usage"; then
+    dokcercompose="docker compose"
   else
     echo "Neither docker-compose nor docker compose found."
     echo "Installation instructions can be found at https://github.com/docker/compose"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treehouses/cli",
-  "version": "1.26.15",
+  "version": "1.26.16",
   "remote": "6000",
   "description": "Thin command-line interface for Raspberry Pi low level configuration.",
   "main": "cli.sh",


### PR DESCRIPTION
fixes #2294 

- [x] is https://docs.docker.com/engine/install/ the the link to show when docker is not installed?